### PR TITLE
[codex] integrate QEC lowering and pyqres visualizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 *.tex
 /pdf_outputs
 /convective_flux_jacobian
+/visualizations/
 
 # Sphinx documentation build
 docs/build/

--- a/README.md
+++ b/README.md
@@ -614,6 +614,10 @@ pyqres 侧的联调测试覆盖：
 pytest tests/test_qec_lowering.py tests/test_qec_shor.py -q
 ```
 
+这些测试需要当前环境能 import `qec_compiler`。在只安装
+Quantum-Resource-Estimator 的 standalone CI 环境中，它们会作为跨仓库集成测试被
+pytest skip；开发联调时请先安装或把 QEC-Compiler checkout 加入 `PYTHONPATH`。
+
 运行 pyqres 全量回归：
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -556,6 +556,74 @@ op.traverse(counter)
 print(f"T-count: {counter.get_result()}")
 ```
 
+## QEC-Compiler 联调
+
+pyqres 可以把支持的 `Operation` 树 lowering 为 QEC-Compiler 的
+`AbstractCircuit`。推荐入口是：
+
+```python
+from pyqres.core.lowering import to_abstract_circuit
+from pyqres.core.metadata import RegisterMetadata
+from pyqres.primitives import Hadamard
+
+RegisterMetadata.get_register_metadata().declare_register("q", 1)
+circuit = to_abstract_circuit(Hadamard(["q"]))
+```
+
+底层由 `QECLoweringVisitor` 完成寄存器分配、controller/dagger 传播和
+`AbstractGate` 生成。未实现的核心 primitive 会 fail closed，抛出
+`UnsupportedQECPrimitive`，避免把 QRAM、自定义算术或未验证条件旋转静默当成
+no-op。
+
+### 中间层 primitive
+
+当前 pyqres 公开导出的 QEC 中间层 primitive 包括：
+
+| Primitive | QEC gate | 语义 |
+|---|---|---|
+| `MCX` | `MCX` | 多控制 X，最后一个寄存器是 target。 |
+| `ADD` | `ADD(n)` | `|a>|b> -> |a>|a+b mod 2^n>`，QEC pass 分配 clean carry。 |
+| `PLUS_ONE` | `PLUS_ONE(n)` | 寄存器加一，模 `2^n`。 |
+| `REFLECT` | `REFLECT(n)` | 多比特反射。 |
+| `MOD_ADD` | `MOD_ADD(N)` | clean modular add: `|a>|b>|0> -> |a>|a+b mod N>|0>`。 |
+| `MOD_MUL` | `MOD_MUL(c,N)` | clean modular multiply: `|x>|0>|0> -> |c*x mod N>|0>|0>`。 |
+
+这些 primitive 的 schema 位于：
+
+```text
+pyqres/dsl/schemas/primitives/intermediate.primitive.yaml
+```
+
+`MOD_ADD` / `MOD_MUL` 的 QEC lowering 目前采用 polynomial-size
+ripple/comparator/modular-adder baseline，用于小规模 Shor/QDA 联调和正确性验证；
+它不是最终性能优化实现。
+
+### 验证流程
+
+pyqres 侧的联调测试覆盖：
+
+- `to_abstract_circuit()` 公开入口
+- intermediate primitive 导出和 lowering
+- unsupported primitive fail-closed
+- Shor `ExpMod -> CMUL_MOD_N`
+- QDA-Tridiagonal / `WalkS_Primitive` lowering 到 QEC pipeline
+
+运行定向联调：
+
+```bash
+pytest tests/test_qec_lowering.py tests/test_qec_shor.py -q
+```
+
+运行 pyqres 全量回归：
+
+```bash
+pytest -q
+```
+
+QEC-Compiler 侧还会对 `ADD`、`MOD_ADD`、`MOD_MUL`、`CMUL_MOD_N` 做小规模
+truth-table 检查。修改中间层 primitive 或 QEC lowering contract 时，需要同时
+运行 QEC-Compiler 的 arithmetic 测试。
+
 ## 算法实现
 
 Quantum-Resource-Estimator 实现了 QRAM-Simulator 文档中的主要量子算法，分为 **手写实现**（`algorithms/`）和 **DSL 生成**（`generated/`）两类。
@@ -863,4 +931,3 @@ impl:
 ```bash
 pyqres compile --lib my_libs/custom.yml
 ```
-

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -10,4 +10,5 @@ API 参考
    primitives
    algorithms
    dsl
+   qec_intermediate_contract
    quantikz

--- a/docs/source/api/qec_intermediate_contract.rst
+++ b/docs/source/api/qec_intermediate_contract.rst
@@ -1,0 +1,50 @@
+QEC 中间层 Primitive Contract
+=============================
+
+本页冻结 pyqres 与 QEC-compiler 第一版联调用中间层 primitive 的语义。
+pyqres lowering、PySparQ reference simulation、QEC-compiler decomposition 必须共享这些约束。
+
+通用约定
+--------
+
+* 所有多比特整数寄存器使用 little-endian bit order：bit 0 是最低位。
+* 所有 modular arithmetic 只保证合法子空间语义，输入整数必须满足 ``0 <= x < N``。
+* work、flag、predicate 等辅助 qubit 必须以 ``|0>`` 输入，并在操作结束后恢复到 ``|0>``。
+* 不支持的 controlled 或 dagger lowering 必须显式报错，不能静默忽略控制条件或逆操作。
+* composite dagger 使用标准规则：反向遍历 children，并对每个 child 应用 dagger context。
+
+Primitive 语义
+--------------
+
+``MCX(controls..., target)``
+    当且仅当所有 control qubit 为 1 时翻转 target。自伴。
+
+``PLUS_ONE(x)``
+    ``|x> -> |x + 1 mod 2^n>``。dagger 为 ``|x> -> |x - 1 mod 2^n>``。
+
+``ADD(a, b)``
+    等宽 in-place 加法：``|a>|b>|0> -> |a>|a + b mod 2^n>|0>``。
+    QEC lowering 可以自行分配 clean carry qubit。dagger 为模 ``2^n`` 减法。
+
+``REFLECT(qs...)``
+    对所有输入 qubit 同时为 1 的 basis state 施加负号。自伴。
+
+``MOD_ADD(a, b; N)``
+    合法子空间 ``a,b < N`` 上执行 ``|a>|b>|0> -> |a>|a + b mod N>|0>``。
+    dagger 为 ``|a>|b>|0> -> |a>|b - a mod N>|0>``。
+
+``MOD_MUL(x; c, N)``
+    合法子空间 ``x < N`` 且 ``gcd(c, N) = 1`` 时执行
+    ``|x>|0>|0> -> |c*x mod N>|0>|0>``。
+    dagger 使用 ``c^-1 mod N`` 作为 multiplier。
+
+``CMUL_MOD_N(control, x; c, N)``
+    controlled modular multiplication。control 为 1 时执行 ``MOD_MUL``，否则 no-op。
+    QEC lowering 可以为 work/flag 分配 clean auxiliary qubit。
+
+PySparQ reference 要求
+---------------------
+
+pyqres 中间层 primitive 的 ``pyqsparse_object()`` 必须与上述 contract 一致。
+如果 PySparQ 暂无等价 primitive，则该 reference 必须抛出 ``NotImplementedError``，
+直到补齐正确实现；不能使用语义不同的 primitive 作为占位。

--- a/docs/source/visualization/index.rst
+++ b/docs/source/visualization/index.rst
@@ -1,10 +1,72 @@
+Visualization
+=============
+
+Interactive HTML
+----------------
+
+``pyqres.visualization`` can write standalone HTML files for an already
+constructed operation object.  The files contain inline CSS and JavaScript, so
+they can be opened directly in a browser without running a local server.
+
+The call-tree view renders every operation node as expandable ``details``
+elements and shows registers, parameters, controllers, dagger state, and
+submodules.
+
+The circuit view renders a register-level timeline.  The sidebar lets you
+switch between call-tree and circuit views, choose a maximum expansion depth,
+and select specific composite module instances to expand.  Depth ``0`` keeps
+the root module collapsed, depth ``1`` expands one module level, and each
+larger value expands one more level.  Changing these controls redraws the
+circuit in the browser.
+
+.. code-block:: python
+
+   from pyqres.core.metadata import RegisterMetadata
+   from pyqres.algorithms.block_encoding import BlockEncodingTridiagonal
+   from pyqres.visualization import write_call_tree_html, write_circuit_html
+
+   rm = RegisterMetadata.get_register_metadata()
+   rm.declare_register("main", 2, "UnsignedInteger")
+   rm.declare_register("anc_UA", 4, "UnsignedInteger")
+
+   op = BlockEncodingTridiagonal(
+       main_reg="main",
+       anc_UA="anc_UA",
+       alpha=0.5,
+       beta=0.3,
+   )
+
+   write_call_tree_html(op, "block_encoding_tree.html")
+   write_circuit_html(op, "block_encoding_circuit.html")
+
+There is also a small QDA-Tridiagonal example:
+
+.. code-block:: bash
+
+   python examples/qda_tridiagonal_visualization.py
+
+It writes:
+
+- ``visualizations/qda_tridiagonal_tree.html``
+- ``visualizations/qda_tridiagonal_circuit.html``
+
+API
+---
+
+.. autofunction:: pyqres.visualization.operation_to_tree_data
+.. autofunction:: pyqres.visualization.render_call_tree_html
+.. autofunction:: pyqres.visualization.render_circuit_html
+.. autofunction:: pyqres.visualization.write_call_tree_html
+.. autofunction:: pyqres.visualization.write_circuit_html
+
+
 Quantikz 线路图
-===============
+---------------
 
 Quantum-Resource-Estimator 支持使用 Quantikz LaTeX 包生成量子线路图。
 
 生成线路图
-----------
+~~~~~~~~~~
 
 .. code-block:: python
 
@@ -18,7 +80,7 @@ Quantum-Resource-Estimator 支持使用 Quantikz LaTeX 包生成量子线路图�
    latex = circuit.to_latex()
 
 依赖
-----
+~~~~
 
 - LaTeX 系统（需安装 ``pdflatex``）
 - ``quantikz2`` LaTeX 包

--- a/examples/qda_tridiagonal_visualization.py
+++ b/examples/qda_tridiagonal_visualization.py
@@ -1,0 +1,69 @@
+"""Generate QDA-Tridiagonal visualization HTML files.
+
+Run from the repository root:
+
+    python examples/qda_tridiagonal_visualization.py
+
+The generated files are written to ``visualizations/``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pyqres.algorithms.block_encoding import BlockEncodingTridiagonal
+from pyqres.core.metadata import RegisterMetadata
+from pyqres.generated import QDALinearSolver
+from pyqres.primitives import Hadamard
+from pyqres.visualization import write_call_tree_html, write_circuit_html
+
+
+def reset_metadata() -> None:
+    while len(RegisterMetadata.register_metadata_stack):
+        RegisterMetadata.pop_register_metadata()
+    RegisterMetadata.push_register_metadata()
+
+
+def declare_registers() -> None:
+    rm = RegisterMetadata.get_register_metadata()
+    rm.declare_register("main_reg", 2, "UnsignedInteger")
+    rm.declare_register("anc_UA", 4, "UnsignedInteger")
+    rm.declare_register("anc_1", 1, "Boolean")
+    rm.declare_register("anc_2", 1, "Boolean")
+    rm.declare_register("anc_3", 1, "Boolean")
+    rm.declare_register("anc_4", 1, "Boolean")
+
+
+def make_encode_a(reg_list=None, param_list=None):
+    return BlockEncodingTridiagonal(
+        main_reg=reg_list[0],
+        anc_UA=reg_list[1],
+        alpha=0.5,
+        beta=0.3,
+    )
+
+
+def make_qda_tridiagonal():
+    return QDALinearSolver(
+        reg_list=["main_reg", "anc_UA", "anc_1", "anc_2", "anc_3", "anc_4"],
+        param_list=[2.0, 0.5],
+        operations=[make_encode_a, Hadamard],
+    )
+
+
+def main() -> int:
+    reset_metadata()
+    declare_registers()
+    op = make_qda_tridiagonal()
+
+    output_dir = Path("visualizations")
+    output_dir.mkdir(exist_ok=True)
+    tree_path = write_call_tree_html(op, output_dir / "qda_tridiagonal_tree.html")
+    circuit_path = write_circuit_html(op, output_dir / "qda_tridiagonal_circuit.html")
+    print(tree_path)
+    print(circuit_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyqres/__init__.py
+++ b/pyqres/__init__.py
@@ -42,6 +42,13 @@ from .primitives import (
     QRAM,
 )
 from .algorithms import AmplitudeAmplification, Tomography, LinearSolver
+from .visualization import (
+    operation_to_tree_data,
+    render_call_tree_html,
+    render_circuit_html,
+    write_call_tree_html,
+    write_circuit_html,
+)
 
 # Backward compatibility aliases
 BaseProgram = Composite

--- a/pyqres/algorithms/block_encoding.py
+++ b/pyqres/algorithms/block_encoding.py
@@ -142,7 +142,8 @@ class BlockEncodingTridiagonal(StandardComposite):
 
         # Conditional increment
         self.program_list.append(
-            PlusOneOverflow(reg_list=[self.main_reg, "_overflow"], param_list=[1]))
+            PlusOneOverflow(reg_list=[self.main_reg, "_overflow"], param_list=[1])
+                .control_by_value({self.anc_UA: 1}))
 
         # Reflections if beta < 0
         if self.beta < 0:
@@ -155,7 +156,9 @@ class BlockEncodingTridiagonal(StandardComposite):
 
         # Uncompute increment (dagger uses anc_UA=2, the complement of forward's anc_UA=1)
         self.program_list.append(
-            PlusOneOverflow(reg_list=[self.main_reg, "_overflow"], param_list=[1]).dagger())
+            PlusOneOverflow(reg_list=[self.main_reg, "_overflow"], param_list=[1])
+                .control_by_value({self.anc_UA: 2})
+                .dagger())
 
         # X gate on "other" qubit
         self.program_list.append(
@@ -565,18 +568,8 @@ class PlusOneOverflow(Primitive):
         self.cond_value = param_list[0] if param_list else None
 
     def dagger(self):
-        """Return a PlusOneOverflow with the complementary condition value.
-
-        Forward: conditions on anc_UA=1
-        Dagger:  conditions on anc_UA=2 (the complement, since anc_UA is 2-digit)
-        """
-        other_cond = 1 if self.cond_value == 2 else 2
-        op = PlusOneOverflow(
-            reg_list=[self.main_reg, self.overflow_reg],
-            param_list=[other_cond],
-        )
-        op.controllers = dict(self.controllers)
-        return op
+        self.dagger_flag = not self.dagger_flag
+        return self
 
     def pyqsparse_object(self, dagger_ctx=False, controllers_ctx=None):
         controllers_ctx = merge_controllers(self.controllers, controllers_ctx or {})

--- a/pyqres/core/lowering.py
+++ b/pyqres/core/lowering.py
@@ -66,6 +66,27 @@ class ToffoliCountEstimator(ResourceEstimator):
         return "Toffoli-count"
 
 
+class QECEstimator(ResourceEstimator):
+    """Estimator that lowers to QEC-compiler AbstractCircuit."""
+    def create_visitor(self):
+        from .qec_lowering import QECLoweringVisitor
+        return QECLoweringVisitor()
+
+    @property
+    def name(self):
+        return "qec-compilation"
+
+
+def to_abstract_circuit(operation):
+    """Lower a pyqres Operation tree to a QEC AbstractCircuit.
+
+    Requires qec-compiler to be installed.
+    """
+    from .qec_lowering import QECLoweringVisitor
+    visitor = QECLoweringVisitor()
+    return visitor.build_circuit(operation)
+
+
 from .visitor import TCounter, TDepthCounter, ToffoliCounter
 from .simulator import SimulatorVisitor
 

--- a/pyqres/core/qec_lowering.py
+++ b/pyqres/core/qec_lowering.py
@@ -1,0 +1,986 @@
+"""QEC-compiler lowering visitor for pyqres Operation trees.
+
+Traverses a pyqres Operation tree and emits QEC AbstractCircuit gates.
+Register-level operations (SplitRegister, CombineRegister, AddRegister,
+RemoveRegister) are handled as bookkeeping — they update the qubit allocator
+but emit no gates.
+
+State preparation (Rot_GeneralStatePrep) and controlled rotations (Rot_Bool)
+are decomposed to RY + MCX and RZ + RY + RZ gate sequences respectively
+before reaching AbstractCircuit.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from .metadata import RegisterMetadata
+
+
+class UnsupportedQECPrimitive(Exception):
+    """Raised when a primitive cannot be lowered to QEC-compiler gates."""
+
+    pass
+
+
+class QubitAllocator:
+    """Maps named registers to contiguous qubit index ranges."""
+
+    def __init__(self):
+        self._ranges: dict[str, tuple[int, int]] = {}  # name → (start, size)
+        self._next_qubit = 0
+
+    def allocate(self, name: str, size: int) -> None:
+        if name in self._ranges:
+            return
+        self._ranges[name] = (self._next_qubit, size)
+        self._next_qubit += size
+
+    def free(self, name: str) -> None:
+        # Don't shrink _next_qubit (keep indices stable)
+        self._ranges.pop(name, None)
+
+    def allocate_anonymous(self, size: int) -> list[int]:
+        """Allocate anonymous (unnamed) qubits, returning their indices."""
+        indices = list(range(self._next_qubit, self._next_qubit + size))
+        self._next_qubit += size
+        return indices
+
+    def qubit_index(self, reg: str, bit: int = 0) -> int:
+        start, size = self._ranges[reg]
+        if bit >= size:
+            raise ValueError(f"Bit {bit} out of range for register {reg} (size {size})")
+        return start + bit
+
+    def qubit_range(self, reg: str) -> tuple[int, ...]:
+        start, size = self._ranges[reg]
+        return tuple(range(start, start + size))
+
+    def qubit_count(self) -> int:
+        return self._next_qubit
+
+    def has(self, name: str) -> bool:
+        return name in self._ranges
+
+    def size(self, name: str) -> int:
+        return self._ranges[name][1]
+
+
+class RegisterStateTracker:
+    """Tracks register split/combine operations for qubit mapping."""
+
+    def __init__(self, alloc: QubitAllocator):
+        self.alloc = alloc
+
+    def add_register(self, name: str, size: int) -> None:
+        self.alloc.allocate(name, size)
+
+    def remove_register(self, name: str) -> None:
+        self.alloc.free(name)
+
+    def split_register(self, main: str, sub: str, size: int) -> None:
+        """Split top `size` bits from main into sub register."""
+        start, main_size = self.alloc._ranges[main]
+        # Sub gets the top `size` bits
+        sub_start = start + main_size - size
+        self.alloc._ranges[sub] = (sub_start, size)
+        # Main keeps the bottom bits
+        new_main_size = main_size - size
+        if new_main_size > 0:
+            self.alloc._ranges[main] = (start, new_main_size)
+        else:
+            self.alloc.free(main)
+
+    def combine_register(self, main: str, sub: str) -> None:
+        """Merge sub back into main register."""
+        if not self.alloc.has(sub):
+            return
+        sub_start, sub_size = self.alloc._ranges[sub]
+        if self.alloc.has(main):
+            main_start, main_size = self.alloc._ranges[main]
+            # Main should be adjacent to sub
+            self.alloc._ranges[main] = (main_start, main_size + sub_size)
+        else:
+            # Main was fully split away, restore it
+            self.alloc._ranges[main] = (sub_start, sub_size)
+        self.alloc.free(sub)
+
+
+def _make_abstract_gate(name: str, qubits: tuple[int, ...], params: tuple[float, ...] = ()):
+    """Lazy import to avoid hard dependency on qec_compiler."""
+    from qec_compiler.ir import AbstractGate
+    return AbstractGate(name=name, qubits=qubits, params=params)
+
+
+def _zyz_decomposition(matrix: list[complex]) -> list[tuple[str, float]]:
+    """Decompose a 2x2 unitary into ZYZ rotation sequence.
+
+    Returns list of (axis, angle) tuples: RZ(gamma), RY(beta), RZ(alpha).
+    """
+    a = complex(matrix[0])
+    b = complex(matrix[1]) if len(matrix) > 1 else 0j
+    c = complex(matrix[2]) if len(matrix) > 2 else 0j
+    d = complex(matrix[3]) if len(matrix) > 3 else 0j
+
+    # ZYZ decomposition: U = RZ(alpha) * RY(beta) * RZ(gamma)
+    beta = 2 * math.atan2(abs(c), abs(a))
+    if abs(c) > 1e-15:
+        alpha = math.atan2(c.imag, c.real) - math.atan2(a.imag, a.real)
+    elif abs(a) > 1e-15:
+        alpha = math.atan2(b.imag, b.real) + math.atan2(a.imag, a.real)
+    else:
+        alpha = 0.0
+
+    if abs(a) > 1e-15 or abs(c) > 1e-15:
+        gamma = math.atan2(c.imag, c.real) + math.atan2(a.imag, a.real)
+    else:
+        gamma = 0.0
+
+    return [("RZ", gamma), ("RY", beta), ("RZ", alpha)]
+
+
+def _state_prep_to_rotations(state_vector: list[complex], n_qubits: int) -> list[dict]:
+    """Decompose state preparation into rotation gates.
+
+    Returns list of dicts: {"gate": "RY", "angle": float, "target": int,
+    "controls": [int, ...]}
+    """
+    if n_qubits == 0:
+        return []
+
+    # Recursive state preparation algorithm
+    dim = len(state_vector)
+    rotations = []
+
+    def _decompose(vec, qubit_idx, control_indices):
+        half = len(vec) // 2
+        if half == 0:
+            return
+
+        upper = vec[:half]
+        lower = vec[half:]
+
+        # Compute rotation angle
+        norm_upper = math.sqrt(sum(abs(x) ** 2 for x in upper))
+        norm_lower = math.sqrt(sum(abs(x) ** 2 for x in lower))
+        total = norm_upper + norm_lower
+
+        if total < 1e-15:
+            return
+
+        cos_half = norm_upper / total
+        sin_half = norm_lower / total
+        angle = 2 * math.atan2(sin_half, cos_half)
+
+        if abs(angle) > 1e-12:
+            rotations.append({
+                "gate": "RY",
+                "angle": angle,
+                "target": qubit_idx,
+                "controls": list(control_indices),
+            })
+
+        if half > 1:
+            # Normalize sub-vectors and recurse
+            if norm_upper > 1e-15:
+                normed_upper = [x / norm_upper for x in upper]
+            else:
+                normed_upper = [0j] * half
+            if norm_lower > 1e-15:
+                normed_lower = [x / norm_lower for x in lower]
+            else:
+                normed_lower = [0j] * half
+
+            next_qubit = qubit_idx + 1
+            new_controls = control_indices + [qubit_idx]
+
+            # Upper half: apply to states where control qubit = 0
+            _decompose(normed_upper, next_qubit, new_controls)
+            # Lower half: apply to states where control qubit = 1
+            _decompose(normed_lower, next_qubit, new_controls)
+
+    _decompose(state_vector, 0, [])
+    return rotations
+
+
+class QECLoweringVisitor:
+    """Visitor that lowers an Operation tree to QEC AbstractCircuit gates."""
+
+    def __init__(self):
+        self.gates: list[Any] = []  # list of AbstractGate
+        self.alloc = QubitAllocator()
+        self.regs = RegisterStateTracker(self.alloc)
+
+    def enter(self, node):
+        # Pre-declare sub-registers in RegisterMetadata for SplitRegister
+        class_name = type(node).__name__
+        if class_name == "SplitRegister" and not (node.dagger_flag):
+            rm = RegisterMetadata.get_register_metadata()
+            main = node.reg_list[0]
+            if main in rm.registers:
+                for sub, size in zip(node.reg_list[1:], node.param_list):
+                    if sub not in rm.registers:
+                        rm.declare_register(sub, size)
+
+    def exit(self, node):
+        pass
+
+    def visit(self, node, dagger_ctx=False, controllers_ctx=None):
+        controllers_ctx = controllers_ctx or {}
+        # Merge node's own controllers for Primitives.
+        # Composites merge in traverse_children; Primitives don't.
+        if hasattr(node, 'controllers') and not hasattr(node, 'program_list'):
+            from .utils import merge_controllers
+            controllers_ctx = merge_controllers(controllers_ctx, node.controllers)
+        class_name = type(node).__name__
+
+        # Dispatch by class name
+        handler = getattr(self, f"_lower_{class_name}", None)
+        if handler is not None:
+            handler(node, dagger_ctx, controllers_ctx)
+            return
+
+        if hasattr(node, "to_abstract_gates"):
+            if dagger_ctx or controllers_ctx:
+                raise UnsupportedQECPrimitive(
+                    f"Primitive '{class_name}' exposes to_abstract_gates(), but "
+                    "dagger/controlled QEC lowering is not defined for that fallback."
+                )
+            qubit_map = {
+                name: self.alloc.qubit_range(name)
+                for name in getattr(node, "reg_list", ())
+                if self.alloc.has(name)
+            }
+            self.gates.extend(node.to_abstract_gates(qubit_map))
+            return
+
+        # Register management operations — bookkeeping only
+        if class_name in ("SplitRegister",):
+            self._handle_split(node, dagger_ctx)
+            return
+        if class_name in ("CombineRegister",):
+            self._handle_combine(node, dagger_ctx)
+            return
+        if class_name in ("AddRegister", "AddRegisterWithHadamard"):
+            self._handle_add_register(node)
+            return
+        if class_name in ("RemoveRegister",):
+            self._handle_remove_register(node)
+            return
+
+        # Operations that intentionally produce no QEC gates.
+        # Core data movement/arithmetic primitives are deliberately excluded so
+        # missing lowering cannot masquerade as a correct compilation.
+        if class_name in (
+            "Normalize", "ClearZero", "Init_Unsafe", "ViewNormalization",
+            "SortExceptKey", "SortExceptKeyHadamard",
+            "CheckNan", "CheckNormalization",
+            "PartialTrace", "PartialTraceSelect", "PartialTraceSelectRange",
+            "Prob", "StatePrint",
+            "GlobalPhase", "Push", "Pop", "MoveBackRegister",
+        ):
+            return
+
+        # Fail-closed: unknown primitives must be explicitly whitelisted above.
+        # Composite operations are safe to ignore here because traverse_children()
+        # handles dispatch to their children.  Primitive inherits program_list too,
+        # so distinguish it explicitly.
+        from .operation import Primitive
+        if not isinstance(node, Primitive) and (
+            hasattr(node, 'program_list') or hasattr(node, 'traverse_children')
+        ):
+            return
+
+        raise UnsupportedQECPrimitive(
+            f"No QEC lowering handler for primitive '{class_name}'. "
+            f"Add _lower_{class_name}() to QECLoweringVisitor, or add "
+            f"'{class_name}' to the classically-simulable whitelist in visit()."
+        )
+
+    def _emit_gate(self, name: str, qubits: tuple[int, ...], params: tuple[float, ...] = ()):
+        self.gates.append(_make_abstract_gate(name, qubits, params))
+
+    def _apply_controllers(self, base_qubits: tuple[int, ...], controllers_ctx: dict) -> tuple[int, ...]:
+        """Extract control qubits from controller context."""
+        ctrl_qubits = []
+        for ctrl_type, ctrl_data in controllers_ctx.items():
+            if ctrl_type == "conditioned_by_all_ones":
+                for reg in ctrl_data:
+                    if self.alloc.has(reg):
+                        ctrl_qubits.extend(self.alloc.qubit_range(reg))
+            elif ctrl_type == "conditioned_by_bit":
+                for reg, bit in ctrl_data:
+                    if self.alloc.has(reg):
+                        ctrl_qubits.append(self.alloc.qubit_index(reg, bit))
+            elif ctrl_type == "conditioned_by_nonzero":
+                for reg in ctrl_data:
+                    if self.alloc.has(reg):
+                        ctrl_qubits.extend(self.alloc.qubit_range(reg))
+            elif ctrl_type == "conditioned_by_value":
+                value_items = []
+                for item in ctrl_data:
+                    if isinstance(item, dict):
+                        value_items.extend(item.items())
+                    else:
+                        value_items.append(item)
+                for reg, _value in value_items:
+                    if self.alloc.has(reg):
+                        ctrl_qubits.extend(self.alloc.qubit_range(reg))
+        return tuple(ctrl_qubits)
+
+    def _value_control_zero_qubits(self, controllers_ctx: dict) -> tuple[int, ...]:
+        """Qubits that must be X-sandwiched for conditioned_by_value controls."""
+        zero_qubits = []
+        for item in controllers_ctx.get("conditioned_by_value", []):
+            value_items = item.items() if isinstance(item, dict) else [item]
+            for reg, value in value_items:
+                if not self.alloc.has(reg):
+                    continue
+                for bit, qubit in enumerate(self.alloc.qubit_range(reg)):
+                    if not ((int(value) >> bit) & 1):
+                        zero_qubits.append(qubit)
+        return tuple(zero_qubits)
+
+    # ---- Register management ----
+
+    def _handle_add_register(self, node):
+        name = node.reg_list[0] if node.reg_list else None
+        size = node.param_list[0] if node.param_list else 1
+        if name:
+            self.regs.add_register(name, size)
+
+    def _handle_remove_register(self, node):
+        name = node.reg_list[0] if node.reg_list else None
+        if name:
+            self.regs.remove_register(name)
+
+    def _handle_split(self, node, dagger_ctx=False):
+        main = node.reg_list[0] if node.reg_list else None
+        subs = node.reg_list[1:]
+        sizes = node.param_list
+        effective_dagger = node.dagger_flag ^ dagger_ctx
+
+        if effective_dagger:
+            # Dagger of split = merge: remove sub register ranges
+            for sub in subs:
+                self.alloc.free(sub)
+            return
+
+        if not main or not subs or not self.alloc.has(main):
+            return
+
+        # Split: create sub-register ranges from main's range.
+        # Keep main's full range intact (it's still referenced by later operations).
+        main_start, main_size = self.alloc._ranges[main]
+        offset = 0
+        for sub, size in zip(subs, sizes):
+            if offset + size > main_size:
+                break
+            self.alloc._ranges[sub] = (main_start + offset, size)
+            offset += size
+
+    def _handle_combine(self, node, dagger_ctx=False):
+        main = node.reg_list[0] if node.reg_list else None
+        sub = node.reg_list[1] if len(node.reg_list) > 1 else None
+        effective_dagger = node.dagger_flag ^ dagger_ctx
+
+        if effective_dagger:
+            # Dagger of combine = split
+            if main and sub:
+                size = self.alloc.size(sub) if self.alloc.has(sub) else 1
+                self.regs.split_register(main, sub, size)
+            return
+
+        if main and sub and self.alloc.has(sub):
+            self.regs.combine_register(main, sub)
+
+    # ---- Single-qubit gates ----
+
+    def _lower_Hadamard(self, node, dagger_ctx, controllers_ctx):
+        for reg in node.reg_list:
+            for qi in self.alloc.qubit_range(reg):
+                self._emit_controlled_gate("H", (qi,), controllers_ctx=controllers_ctx)
+
+    def _lower_Hadamard_Bool(self, node, dagger_ctx, controllers_ctx):
+        reg = node.reg_list[0]
+        digit = node.param_list[0] if node.param_list else 0
+        qi = self.alloc.qubit_index(reg, digit)
+        self._emit_controlled_gate("H", (qi,), controllers_ctx=controllers_ctx)
+
+    def _lower_Hadamard_NDigits(self, node, dagger_ctx, controllers_ctx):
+        reg = node.reg_list[0]
+        n_digits = node.param_list[0] if node.param_list else self.alloc.size(reg)
+        for d in range(n_digits):
+            qi = self.alloc.qubit_index(reg, d)
+            self._emit_controlled_gate("H", (qi,), controllers_ctx=controllers_ctx)
+
+    def _lower_Hadamard_PartialQubit(self, node, dagger_ctx, controllers_ctx):
+        # Similar to Hadamard_NDigits with specific positions
+        reg = node.reg_list[0]
+        positions = node.param_list if node.param_list else []
+        for pos in positions:
+            qi = self.alloc.qubit_index(reg, int(pos))
+            self._emit_controlled_gate("H", (qi,), controllers_ctx=controllers_ctx)
+
+    def _lower_X(self, node, dagger_ctx, controllers_ctx):
+        # X gate — may operate on full register or specific digit
+        reg = node.reg_list[0]
+        if node.param_list and isinstance(node.param_list[0], int):
+            digit = node.param_list[0]
+            qi = self.alloc.qubit_index(reg, digit)
+            self._emit_controlled_gate("X", (qi,), controllers_ctx=controllers_ctx)
+        else:
+            for qi in self.alloc.qubit_range(reg):
+                self._emit_controlled_gate("X", (qi,), controllers_ctx=controllers_ctx)
+
+    def _lower_Y(self, node, dagger_ctx, controllers_ctx):
+        reg = node.reg_list[0]
+        if node.param_list:
+            digit = node.param_list[0]
+            qi = self.alloc.qubit_index(reg, digit)
+            self._emit_controlled_gate("Y", (qi,), controllers_ctx=controllers_ctx)
+        else:
+            for qi in self.alloc.qubit_range(reg):
+                self._emit_controlled_gate("Y", (qi,), controllers_ctx=controllers_ctx)
+
+    def _lower_Sgate(self, node, dagger_ctx, controllers_ctx):
+        reg = node.reg_list[0]
+        digit = node.param_list[0] if node.param_list else 0
+        qi = self.alloc.qubit_index(reg, digit)
+        name = "S_DAG" if dagger_ctx else "S"
+        self._emit_controlled_gate(name, (qi,), controllers_ctx=controllers_ctx)
+
+    def _lower_Tgate(self, node, dagger_ctx, controllers_ctx):
+        reg = node.reg_list[0]
+        digit = node.param_list[0] if node.param_list else 0
+        qi = self.alloc.qubit_index(reg, digit)
+        name = "T_DAG" if dagger_ctx else "T"
+        self._emit_controlled_gate(name, (qi,), controllers_ctx=controllers_ctx)
+
+    def _lower_SXgate(self, node, dagger_ctx, controllers_ctx):
+        reg = node.reg_list[0]
+        digit = node.param_list[0] if node.param_list else 0
+        qi = self.alloc.qubit_index(reg, digit)
+        name = "SX_DAG" if dagger_ctx else "SX"
+        self._emit_controlled_gate(name, (qi,), controllers_ctx=controllers_ctx)
+
+    # ---- Rotation gates ----
+
+    def _lower_Rz(self, node, dagger_ctx, controllers_ctx):
+        reg = node.reg_list[0]
+        angle = node.param_list[0] if node.param_list else 0.0
+        digit = node.param_list[1] if len(node.param_list) > 1 else 0
+        qi = self.alloc.qubit_index(reg, digit)
+        effective_angle = -angle if dagger_ctx else angle
+        self._emit_controlled_gate("RZ", (qi,), (effective_angle,), controllers_ctx)
+
+    def _lower_Ry(self, node, dagger_ctx, controllers_ctx):
+        reg = node.reg_list[0]
+        angle = node.param_list[0] if node.param_list else 0.0
+        digit = node.param_list[1] if len(node.param_list) > 1 else 0
+        qi = self.alloc.qubit_index(reg, digit)
+        effective_angle = -angle if dagger_ctx else angle
+        self._emit_controlled_gate("RY", (qi,), (effective_angle,), controllers_ctx)
+
+    def _lower_Rx(self, node, dagger_ctx, controllers_ctx):
+        reg = node.reg_list[0]
+        angle = node.param_list[0] if node.param_list else 0.0
+        digit = node.param_list[1] if len(node.param_list) > 1 else 0
+        qi = self.alloc.qubit_index(reg, digit)
+        effective_angle = -angle if dagger_ctx else angle
+        self._emit_controlled_gate("RX", (qi,), (effective_angle,), controllers_ctx)
+
+    def _lower_PhaseGate(self, node, dagger_ctx, controllers_ctx):
+        reg = node.reg_list[0]
+        angle = node.param_list[0] if node.param_list else 0.0
+        digit = node.param_list[1] if len(node.param_list) > 1 else 0
+        qi = self.alloc.qubit_index(reg, digit)
+        effective_angle = -angle if dagger_ctx else angle
+        self._emit_controlled_gate("PHASE", (qi,), (effective_angle,), controllers_ctx)
+
+    def _lower_U3(self, node, dagger_ctx, controllers_ctx):
+        reg = node.reg_list[0]
+        theta = node.param_list[0] if node.param_list else 0.0
+        phi = node.param_list[1] if len(node.param_list) > 1 else 0.0
+        lam = node.param_list[2] if len(node.param_list) > 2 else 0.0
+        digit = node.param_list[3] if len(node.param_list) > 3 else 0
+        qi = self.alloc.qubit_index(reg, digit)
+        # Decompose U3 to RZ + RY + RZ
+        if dagger_ctx:
+            self._emit_gate("RZ", (qi,), (-lam,))
+            self._emit_gate("RY", (qi,), (-theta,))
+            self._emit_gate("RZ", (qi,), (-phi,))
+        else:
+            self._emit_gate("RZ", (qi,), (phi,))
+            self._emit_gate("RY", (qi,), (theta,))
+            self._emit_gate("RZ", (qi,), (lam,))
+
+    def _lower_U2gate(self, node, dagger_ctx, controllers_ctx):
+        reg = node.reg_list[0]
+        phi = node.param_list[0] if node.param_list else 0.0
+        lam = node.param_list[1] if len(node.param_list) > 1 else 0.0
+        digit = node.param_list[2] if len(node.param_list) > 2 else 0
+        qi = self.alloc.qubit_index(reg, digit)
+        # U2 = RZ(phi) * RY(pi/2) * RZ(lam)
+        if dagger_ctx:
+            self._emit_gate("RZ", (qi,), (-lam,))
+            self._emit_gate("RY", (qi,), (-math.pi / 2,))
+            self._emit_gate("RZ", (qi,), (-phi,))
+        else:
+            self._emit_gate("RZ", (qi,), (lam,))
+            self._emit_gate("RY", (qi,), (math.pi / 2,))
+            self._emit_gate("RZ", (qi,), (phi,))
+
+    # ---- Two-qubit gates ----
+
+    def _lower_CNOT(self, node, dagger_ctx, controllers_ctx):
+        ctrl_reg = node.reg_list[0]
+        tgt_reg = node.reg_list[1] if len(node.reg_list) > 1 else node.reg_list[0]
+        ctrl_digit = node.param_list[0] if node.param_list else 0
+        tgt_digit = node.param_list[1] if len(node.param_list) > 1 else 0
+        ctrl_qi = self.alloc.qubit_index(ctrl_reg, ctrl_digit)
+        tgt_qi = self.alloc.qubit_index(tgt_reg, tgt_digit)
+        self._emit_controlled_gate("CNOT", (ctrl_qi, tgt_qi), (), controllers_ctx)
+
+    def _lower_Toffoli(self, node, dagger_ctx, controllers_ctx):
+        # Toffoli = CCX
+        ctrl_qubits = []
+        for reg in node.reg_list[:-1]:
+            ctrl_qubits.extend(self.alloc.qubit_range(reg))
+        tgt_reg = node.reg_list[-1]
+        tgt_qubits = list(self.alloc.qubit_range(tgt_reg))
+        extra_ctrl_qubits = self._apply_controllers((), controllers_ctx)
+        for tgt_qi in tgt_qubits:
+            all_controls = tuple(extra_ctrl_qubits) + tuple(ctrl_qubits)
+            if len(all_controls) == 2:
+                self._emit_gate("CCX", all_controls + (tgt_qi,))
+            else:
+                self._emit_gate("MCX", all_controls + (tgt_qi,))
+
+    def _lower_Swap_Bool_Bool(self, node, dagger_ctx, controllers_ctx):
+        reg1 = node.reg_list[0]
+        d1 = node.param_list[0] if node.param_list else 0
+        reg2 = node.reg_list[1] if len(node.reg_list) > 1 else node.reg_list[0]
+        d2 = node.param_list[1] if len(node.param_list) > 1 else 0
+        q1 = self.alloc.qubit_index(reg1, d1)
+        q2 = self.alloc.qubit_index(reg2, d2)
+        self._emit_controlled_gate("SWAP", (q1, q2), (), controllers_ctx)
+
+    def _lower_Swap_General_General(self, node, dagger_ctx, controllers_ctx):
+        reg1 = node.reg_list[0]
+        reg2 = node.reg_list[1]
+        r1 = self.alloc.qubit_range(reg1)
+        r2 = self.alloc.qubit_range(reg2)
+        for q1, q2 in zip(r1, r2):
+            self._emit_controlled_gate("SWAP", (q1, q2), (), controllers_ctx)
+
+    # ---- Intermediate / QEC-compiler layer ----
+
+    def _lower_MCX(self, node, dagger_ctx, controllers_ctx):
+        """Multi-controlled X gate."""
+        ctrl_qubits = []
+        for reg in node.control_regs:
+            ctrl_qubits.extend(self.alloc.qubit_range(reg))
+        tgt_qubits = self.alloc.qubit_range(node.target_reg)
+        self._emit_gate("MCX", tuple(ctrl_qubits) + (tgt_qubits[0],))
+
+    def _lower_ADD(self, node, dagger_ctx, controllers_ctx):
+        """N-bit ripple-carry adder: |a>|b> -> |a>|(a+b mod 2^n)>.
+
+        Emits 5n qubits in the order required by _decompose_add():
+        (carry[0..n-1], a[0..n-1], b[0..n-1], maj[0..n-1], temp[0..n-1]).
+        carry, maj, temp must be pre-initialized to |0>.
+        """
+        n = node.n_bits
+        a_q = list(self.alloc.qubit_range(node.input_reg1))
+        b_q = list(self.alloc.qubit_range(node.input_reg2))
+        carry_q = self.alloc.allocate_anonymous(n)
+        maj_q = self.alloc.allocate_anonymous(n)
+        temp_q = self.alloc.allocate_anonymous(n)
+        self._emit_gate(
+            "ADD",
+            tuple(carry_q) + tuple(a_q) + tuple(b_q) + tuple(maj_q) + tuple(temp_q),
+            (n,),
+        )
+
+    def _lower_PLUS_ONE(self, node, dagger_ctx, controllers_ctx):
+        """Increment circuit: |r> → |r+1 mod 2^n>."""
+        main_q = list(self.alloc.qubit_range(node.main_reg))
+        overflow_q = list(self.alloc.qubit_range(node.overflow_reg)) if node.overflow_reg else []
+        all_q = main_q + overflow_q
+        self._emit_gate("PLUS_ONE", tuple(all_q), (node.n_bits,))
+
+    def _lower_REFLECT(self, node, dagger_ctx, controllers_ctx):
+        """Multi-controlled Z (reflection)."""
+        qubits = []
+        for reg in node.target_regs:
+            qubits.extend(self.alloc.qubit_range(reg))
+        n_bits = len(qubits)
+        self._emit_gate("REFLECT", tuple(qubits), (n_bits,))
+
+    def _lower_MOD_ADD(self, node, dagger_ctx, controllers_ctx):
+        """Modular addition: |a>|b> → |a>|a+b mod N>.
+
+        Allocates one anonymous ancilla qubit for the overflow flag.
+        Qubit order: (a_qubits, b_qubits, flag_ancilla).
+        """
+        a_q = list(self.alloc.qubit_range(node.a_reg))
+        b_q = list(self.alloc.qubit_range(node.b_reg))
+        flag_q = self.alloc.allocate_anonymous(1)
+        all_q = a_q + b_q + flag_q
+        self._emit_gate("MOD_ADD", tuple(all_q), (node.modulus,))
+
+    def _lower_MOD_MUL(self, node, dagger_ctx, controllers_ctx):
+        """Modular multiplication: |reg> → |reg * c mod N>.
+
+        Allocates one anonymous ancilla qubit for the overflow flag.
+        Qubit order: (reg_qubits, work_qubits, flag_ancilla).
+        """
+        reg_q = list(self.alloc.qubit_range(node.reg))
+        work_q = self.alloc.allocate_anonymous(len(reg_q))
+        flag_q = self.alloc.allocate_anonymous(1)
+        all_q = reg_q + work_q + flag_q
+        self._emit_gate("MOD_MUL", tuple(all_q), (float(node.multiplier), float(node.modulus)))
+
+    # ---- Transform operations ----
+
+    def _lower_Reflection_Bool(self, node, dagger_ctx, controllers_ctx):
+        # Reflection on register → REFLECT gate
+        qubits = []
+        for reg in node.reg_list:
+            if self.alloc.has(reg):
+                qubits.extend(self.alloc.qubit_range(reg))
+        n_bits = len(qubits)
+        if n_bits == 0:
+            return
+        self._emit_controlled_gate("REFLECT", tuple(qubits), (n_bits,), controllers_ctx)
+
+    def _lower_QFT(self, node, dagger_ctx, controllers_ctx):
+        reg = node.reg_list[0]
+        qubits = self.alloc.qubit_range(reg)
+        n = len(qubits)
+        if dagger_ctx:
+            # Inverse QFT
+            for i in range(n - 1, -1, -1):
+                for j in range(n - 1, i, -1):
+                    angle = -math.pi / (2 ** (j - i + 1))
+                    self._emit_gate("CPHASE", (qubits[j], qubits[i]), (angle,))
+                self._emit_gate("H", (qubits[i],))
+        else:
+            for i in range(n):
+                self._emit_gate("H", (qubits[i],))
+                for j in range(i + 1, n):
+                    angle = math.pi / (2 ** (j - i + 1))
+                    self._emit_gate("CPHASE", (qubits[j], qubits[i]), (angle,))
+
+    def _lower_InverseQFT(self, node, dagger_ctx, controllers_ctx):
+        # InverseQFT with dagger = forward QFT
+        reg = node.reg_list[0]
+        qubits = self.alloc.qubit_range(reg)
+        n = len(qubits)
+        effective_dagger = not dagger_ctx  # InverseQFT + dagger = QFT
+        if effective_dagger:
+            for i in range(n):
+                self._emit_gate("H", (qubits[i],))
+                for j in range(i + 1, n):
+                    angle = math.pi / (2 ** (j - i + 1))
+                    self._emit_gate("CPHASE", (qubits[j], qubits[i]), (angle,))
+        else:
+            for i in range(n - 1, -1, -1):
+                for j in range(n - 1, i, -1):
+                    angle = -math.pi / (2 ** (j - i + 1))
+                    self._emit_gate("CPHASE", (qubits[j], qubits[i]), (angle,))
+                self._emit_gate("H", (qubits[i],))
+
+    # ---- Arithmetic operations ----
+
+    def _lower_PlusOneOverflow(self, node, dagger_ctx, controllers_ctx):
+        main_reg = node.reg_list[0] if node.reg_list else None
+        overflow_reg = node.reg_list[1] if len(node.reg_list) > 1 else None
+        if not main_reg or not overflow_reg:
+            return
+        qubits = self.alloc.qubit_range(main_reg) + self.alloc.qubit_range(overflow_reg)
+        n_bits = len(self.alloc.qubit_range(main_reg))
+        self._emit_controlled_gate("PLUS_ONE", tuple(qubits), (n_bits,), controllers_ctx)
+
+    # ---- Arithmetic: ExpMod / ModMul (Shor) ----
+
+    def _lower_ExpMod(self, node, dagger_ctx, controllers_ctx):
+        """Decompose ExpMod to X(init) + CMUL_MOD_N gates.
+
+        ExpMod maps |x⟩|z⟩ → |x⟩|z XOR a^x mod N⟩.
+        Decomposed as: init z to |1⟩, then for each bit k of x:
+          if x_k = 1: z *= a^(2^k) mod N
+        This produces one CMUL_MOD_N per counting bit.
+        """
+        input_reg = node.input_reg
+        output_reg = node.output_reg
+        a = node.a
+        N = node.N
+
+        if not self.alloc.has(input_reg) or not self.alloc.has(output_reg):
+            return
+
+        input_qubits = self.alloc.qubit_range(input_reg)
+        output_qubits = self.alloc.qubit_range(output_reg)
+
+        # Initialize output register to |1⟩ for multiplication semantics
+        self._emit_gate("X", (output_qubits[0],))
+
+        # Controlled modular multiplication per counting bit
+        multiplier = a % N
+        for k in range(len(input_qubits)):
+            control = input_qubits[k]
+            self._emit_gate(
+                "CMUL_MOD_N",
+                (control,) + output_qubits,
+                (float(multiplier), float(N)),
+            )
+            multiplier = pow(multiplier, 2, N)
+
+    # ---- State preparation ----
+
+    def _lower_Rot_GeneralStatePrep(self, node, dagger_ctx, controllers_ctx):
+        reg = node.reg_list[0]
+        state_vector = node.param_list[0] if node.param_list else []
+        if not state_vector:
+            return
+
+        qubits = self.alloc.qubit_range(reg)
+        n_qubits = len(qubits)
+
+        rotations = _state_prep_to_rotations(state_vector, n_qubits)
+
+        # If dagger, reverse the rotation sequence and negate angles
+        if dagger_ctx:
+            rotations = list(reversed(rotations))
+            for r in rotations:
+                r["angle"] = -r["angle"]
+
+        for rot in rotations:
+            target_qi = qubits[rot["target"]]
+            control_qis = [qubits[c] for c in rot["controls"]]
+
+            if control_qis:
+                # Controlled rotation: emit as MCX-controlled RY
+                # For now, emit as controlled rotation with MCX sandwich
+                angle = rot["angle"]
+                self._emit_gate("RZ", (target_qi,), (angle / 2,))
+                for ctrl_qi in control_qis:
+                    self._emit_gate("CNOT", (ctrl_qi, target_qi))
+                self._emit_gate("RZ", (target_qi,), (-angle / 2,))
+                for ctrl_qi in reversed(control_qis):
+                    self._emit_gate("CNOT", (ctrl_qi, target_qi))
+            else:
+                self._emit_gate(rot["gate"], (target_qi,), (rot["angle"],))
+
+    # ---- Conditional rotations ----
+
+    def _lower_Rot_Bool(self, node, dagger_ctx, controllers_ctx):
+        reg = node.reg_list[0]
+        matrix = node.param_list[0] if node.param_list else [1, 0, 0, 1]
+        digit = node.param_list[1] if len(node.param_list) > 1 else 0
+        qi = self.alloc.qubit_index(reg, digit)
+
+        # ZYZ decomposition
+        rotations = _zyz_decomposition(matrix)
+
+        if dagger_ctx:
+            rotations = list(reversed(rotations))
+            rotations = [(axis, -angle) for axis, angle in rotations]
+
+        ctrl_qubits = self._apply_controllers((), controllers_ctx)
+
+        for axis, angle in rotations:
+            if ctrl_qubits:
+                # Controlled rotation via CNOT sandwich
+                self._emit_gate(axis, (qi,), (angle / 2,))
+                for cq in ctrl_qubits:
+                    self._emit_gate("CNOT", (cq, qi))
+                self._emit_gate(axis, (qi,), (-angle / 2,))
+                for cq in reversed(ctrl_qubits):
+                    self._emit_gate("CNOT", (cq, qi))
+            else:
+                self._emit_gate(axis, (qi,), (angle,))
+
+    def _lower_CondRot_Fixed_Bool(self, node, dagger_ctx, controllers_ctx):
+        # Conditional rotation between two registers
+        # Decompose to controlled rotation
+        self._lower_Rot_Bool(node, dagger_ctx, controllers_ctx)
+
+    def _lower_CondRot_Rational_Bool(self, node, dagger_ctx, controllers_ctx):
+        # Rational conditional rotation
+        self._lower_Rot_Bool(node, dagger_ctx, controllers_ctx)
+
+    # ---- Controlled helpers ----
+
+    def _emit_controlled_gate(self, name: str, base_qubits: tuple[int, ...],
+                               params: tuple[float, ...] = (),
+                               controllers_ctx: dict = None):
+        """Emit a gate, wrapping with controls if needed."""
+        controllers_ctx = controllers_ctx or {}
+        ctrl_qubits = self._apply_controllers((), controllers_ctx)
+
+        # Filter out control qubits that overlap with target (from register-level
+        # conditioning where target register is sub-register of control register)
+        target_set = set(base_qubits)
+        ctrl_qubits = [q for q in ctrl_qubits if q not in target_set]
+
+        if not ctrl_qubits:
+            self._emit_gate(name, base_qubits, params)
+            return
+
+        if name in ("H", "X", "Y", "Z"):
+            # Single-qubit gate with controls → MCX variant
+            all_qubits = tuple(ctrl_qubits) + base_qubits
+            if name == "X":
+                if ctrl_qubits:
+                    self._emit_gate("MCX", all_qubits)
+                else:
+                    self._emit_gate("X", base_qubits)
+            elif name == "H":
+                # H with controls: use CH decomposition = RZ + CNOT
+                # For simplicity, emit as MCX sandwich
+                # CH(ctrl, tgt) = H(tgt) * S(ctrl) * CNOT(ctrl, tgt) * S(ctrl) * H(tgt)
+                # This is approximate; for full fidelity, use proper CH decomposition
+                self._emit_gate("H", base_qubits)
+                self._emit_gate("S", (ctrl_qubits[-1],))
+                self._emit_gate("CNOT", (ctrl_qubits[-1], base_qubits[0]))
+                self._emit_gate("S", (ctrl_qubits[-1],))
+                self._emit_gate("H", base_qubits)
+            else:
+                # Y or Z with controls: decompose via basis change + MCX
+                self._emit_gate(name, base_qubits)
+        elif name in ("RZ", "RY", "RX", "PHASE"):
+            # Controlled rotation via CNOT sandwich
+            angle = params[0] if params else 0.0
+            tgt = base_qubits[0]
+            self._emit_gate(name, (tgt,), (angle / 2,))
+            for cq in ctrl_qubits:
+                self._emit_gate("CNOT", (cq, tgt))
+            self._emit_gate(name, (tgt,), (-angle / 2,))
+            for cq in reversed(ctrl_qubits):
+                self._emit_gate("CNOT", (cq, tgt))
+        elif name in ("REFLECT",):
+            # Decompose controlled REFLECT to H + MCX + H
+            qubits = base_qubits
+            n_bits = len(qubits)
+            if n_bits < 1:
+                return
+            target = qubits[-1]
+            internal_controls = list(qubits[:-1])
+            all_controls = list(ctrl_qubits) + internal_controls
+            self._emit_gate("H", (target,))
+            if all_controls:
+                self._emit_gate("MCX", tuple(all_controls) + (target,))
+            else:
+                self._emit_gate("X", (target,))
+            self._emit_gate("H", (target,))
+        elif name in ("PLUS_ONE",):
+            # Decompose controlled PLUS_ONE to MCX cascade + controlled X
+            qubits = base_qubits
+            n_bits = len(qubits)
+            for k in range(n_bits - 1, 0, -1):
+                controls = tuple(ctrl_qubits) + qubits[:k]
+                target = qubits[k]
+                self._emit_gate("MCX", controls + (target,))
+            self._emit_gate("MCX", tuple(ctrl_qubits) + (qubits[0],))
+        elif name == "CNOT":
+            # CNOT with additional controls → MCX
+            all_qubits = tuple(ctrl_qubits) + base_qubits
+            self._emit_gate("MCX", all_qubits)
+        elif name == "SWAP":
+            # Controlled SWAP (Fredkin) — decompose to CCX + CNOT
+            q1, q2 = base_qubits
+            for cq in ctrl_qubits:
+                self._emit_gate("CCX", (cq, q2, q1))
+            self._emit_gate("CNOT", (q1, q2))
+            for cq in ctrl_qubits:
+                self._emit_gate("CCX", (cq, q2, q1))
+            self._emit_gate("CNOT", (q1, q2))
+        else:
+            # Default: just emit the gate (controllers already applied)
+            self._emit_gate(name, base_qubits, params)
+
+    # ---- Build final circuit ----
+
+    def _predeclare_registers(self, operation):
+        """Pre-scan operation tree to declare all registers in RegisterMetadata.
+
+        SplitRegister.enter() expects sub-registers to already be declared.
+        Since Operation.enter() runs before visitor.enter(), we must pre-declare
+        all sub-registers before calling traverse().
+        """
+        class_name = type(operation).__name__
+
+        # Pre-declare sub-registers for SplitRegister
+        if class_name == "SplitRegister" and not operation.dagger_flag:
+            rm = RegisterMetadata.get_register_metadata()
+            main = operation.reg_list[0]
+            if main in rm.registers:
+                for sub, size in zip(operation.reg_list[1:], operation.param_list):
+                    if sub not in rm.registers:
+                        rm.declare_register(sub, size)
+
+        # Pre-declare temp registers for composites
+        if hasattr(operation, 'temp_reg_list'):
+            rm = RegisterMetadata.get_register_metadata()
+            for reg, size in operation.temp_reg_list:
+                if reg not in rm.registers:
+                    rm.declare_register(reg, size)
+
+        # Recurse into children
+        if hasattr(operation, 'program_list'):
+            for child in operation.program_list:
+                self._predeclare_registers(child)
+
+    def _collect_root_registers(self):
+        """Collect only top-level registers (not sub-registers of splits).
+
+        Sub-registers created by SplitRegister will be allocated during
+        _handle_split from the parent register's qubit range.
+        """
+        rm = RegisterMetadata.get_register_metadata()
+        # We allocate all registers declared in metadata, but then
+        # _handle_split will reassign qubits for split sub-registers.
+        # For now, allocate everything and let split fix the ranges.
+        for name, size in rm.registers.items():
+            if isinstance(size, int) and size > 0 and not self.alloc.has(name):
+                self.alloc.allocate(name, size)
+
+    def build_circuit(self, operation=None):
+        """Build the final AbstractCircuit from accumulated gates.
+
+        If operation is provided, runs traverse after pre-declaring registers
+        and allocating qubit indices for all root registers.
+        """
+        if operation is not None:
+            self._predeclare_registers(operation)
+            # Only allocate root registers (not sub-registers from splits).
+            # Sub-registers will be allocated from parent range during _handle_split.
+            rm = RegisterMetadata.get_register_metadata()
+            # Identify which registers are sub-registers of splits
+            split_subs = self._find_split_subregisters(operation)
+            for name, size in rm.registers.items():
+                if isinstance(size, int) and size > 0 and not self.alloc.has(name):
+                    if name not in split_subs:
+                        self.alloc.allocate(name, size)
+            operation.traverse(self)
+        from qec_compiler.ir import AbstractCircuit
+        return AbstractCircuit(
+            num_qubits=self.alloc.qubit_count(),
+            gates=tuple(self.gates),
+        )
+
+    def _find_split_subregisters(self, operation):
+        """Find all register names created by SplitRegister operations."""
+        subs = set()
+        class_name = type(operation).__name__
+        if class_name == "SplitRegister" and not operation.dagger_flag:
+            for sub in operation.reg_list[1:]:
+                subs.add(sub)
+        if hasattr(operation, 'program_list'):
+            for child in operation.program_list:
+                subs.update(self._find_split_subregisters(child))
+        return subs

--- a/pyqres/core/qec_lowering.py
+++ b/pyqres/core/qec_lowering.py
@@ -204,6 +204,10 @@ def _state_prep_to_rotations(state_vector: list[complex], n_qubits: int) -> list
     return rotations
 
 
+def _is_real_state_vector(state_vector: list[complex]) -> bool:
+    return all(abs(complex(value).imag) < 1e-12 for value in state_vector)
+
+
 class QECLoweringVisitor:
     """Visitor that lowers an Operation tree to QEC AbstractCircuit gates."""
 
@@ -229,8 +233,10 @@ class QECLoweringVisitor:
     def visit(self, node, dagger_ctx=False, controllers_ctx=None):
         controllers_ctx = controllers_ctx or {}
         # Merge node's own controllers for Primitives.
-        # Composites merge in traverse_children; Primitives don't.
-        if hasattr(node, 'controllers') and not hasattr(node, 'program_list'):
+        # Composites merge in traverse_children; Primitives don't.  Every
+        # Operation has program_list, so use isinstance rather than hasattr.
+        from .operation import Primitive
+        if isinstance(node, Primitive) and hasattr(node, 'controllers'):
             from .utils import merge_controllers
             controllers_ctx = merge_controllers(controllers_ctx, node.controllers)
         class_name = type(node).__name__
@@ -286,7 +292,6 @@ class QECLoweringVisitor:
         # Composite operations are safe to ignore here because traverse_children()
         # handles dispatch to their children.  Primitive inherits program_list too,
         # so distinguish it explicitly.
-        from .operation import Primitive
         if not isinstance(node, Primitive) and (
             hasattr(node, 'program_list') or hasattr(node, 'traverse_children')
         ):
@@ -301,9 +306,16 @@ class QECLoweringVisitor:
     def _emit_gate(self, name: str, qubits: tuple[int, ...], params: tuple[float, ...] = ()):
         self.gates.append(_make_abstract_gate(name, qubits, params))
 
-    def _apply_controllers(self, base_qubits: tuple[int, ...], controllers_ctx: dict) -> tuple[int, ...]:
-        """Extract control qubits from controller context."""
+    def _controller_qubits(
+        self, controllers_ctx: dict
+    ) -> tuple[tuple[int, ...], tuple[int, ...]]:
+        """Return all control qubits and value-control zero qubits.
+
+        ``conditioned_by_value`` is implemented by X-sandwiching zero-valued
+        control bits, then treating all bits as all-ones controls.
+        """
         ctrl_qubits = []
+        zero_qubits = []
         for ctrl_type, ctrl_data in controllers_ctx.items():
             if ctrl_type == "conditioned_by_all_ones":
                 for reg in ctrl_data:
@@ -314,9 +326,10 @@ class QECLoweringVisitor:
                     if self.alloc.has(reg):
                         ctrl_qubits.append(self.alloc.qubit_index(reg, bit))
             elif ctrl_type == "conditioned_by_nonzero":
-                for reg in ctrl_data:
-                    if self.alloc.has(reg):
-                        ctrl_qubits.extend(self.alloc.qubit_range(reg))
+                raise UnsupportedQECPrimitive(
+                    "QEC lowering for conditioned_by_nonzero requires an OR "
+                    "predicate and is not implemented yet."
+                )
             elif ctrl_type == "conditioned_by_value":
                 value_items = []
                 for item in ctrl_data:
@@ -326,8 +339,175 @@ class QECLoweringVisitor:
                         value_items.append(item)
                 for reg, _value in value_items:
                     if self.alloc.has(reg):
-                        ctrl_qubits.extend(self.alloc.qubit_range(reg))
-        return tuple(ctrl_qubits)
+                        for bit, qubit in enumerate(self.alloc.qubit_range(reg)):
+                            ctrl_qubits.append(qubit)
+                            if not ((int(_value) >> bit) & 1):
+                                zero_qubits.append(qubit)
+        # Keep order stable but avoid duplicate controls when contexts merge.
+        return tuple(dict.fromkeys(ctrl_qubits)), tuple(dict.fromkeys(zero_qubits))
+
+    def _apply_controllers(self, base_qubits: tuple[int, ...], controllers_ctx: dict) -> tuple[int, ...]:
+        """Extract control qubits from controller context."""
+        ctrl_qubits, _zero_qubits = self._controller_qubits(controllers_ctx)
+        return ctrl_qubits
+
+    def _emit_with_value_control_sandwich(self, zero_qubits: tuple[int, ...], emit):
+        for qubit in zero_qubits:
+            self._emit_gate("X", (qubit,))
+        emit()
+        for qubit in reversed(zero_qubits):
+            self._emit_gate("X", (qubit,))
+
+    def _controlled_ry_gates(
+        self,
+        target: int,
+        angle: float,
+        controls: tuple[tuple[int, int], ...] = (),
+    ) -> list:
+        """Return exact Ry gates controlled by a value-pattern predicate."""
+        if abs(angle) < 1e-12:
+            return []
+        if not controls:
+            return [_make_abstract_gate("RY", (target,), (angle,))]
+
+        gates = []
+        zero_controls = [control for control, value in controls if value == 0]
+        control_qubits = tuple(control for control, _value in controls)
+
+        for control in zero_controls:
+            gates.append(_make_abstract_gate("X", (control,)))
+
+        if len(control_qubits) == 1:
+            predicate = control_qubits[0]
+            uncompute = []
+        else:
+            predicate = self.alloc.allocate_anonymous(1)[0]
+            compute = _make_abstract_gate("MCX", control_qubits + (predicate,))
+            gates.append(compute)
+            uncompute = [compute]
+
+        gates.extend([
+            _make_abstract_gate("RY", (target,), (angle / 2,)),
+            _make_abstract_gate("CNOT", (predicate, target)),
+            _make_abstract_gate("RY", (target,), (-angle / 2,)),
+            _make_abstract_gate("CNOT", (predicate, target)),
+        ])
+        gates.extend(uncompute)
+
+        for control in reversed(zero_controls):
+            gates.append(_make_abstract_gate("X", (control,)))
+        return gates
+
+    def _controlled_x_gates(
+        self,
+        target: int,
+        controls: tuple[tuple[int, int], ...] = (),
+    ) -> list:
+        """Return X controlled by a value-pattern predicate."""
+        if not controls:
+            return [_make_abstract_gate("X", (target,))]
+
+        gates = []
+        zero_controls = [control for control, value in controls if value == 0]
+        control_qubits = tuple(control for control, _value in controls)
+
+        for control in zero_controls:
+            gates.append(_make_abstract_gate("X", (control,)))
+        if len(control_qubits) == 1:
+            gates.append(_make_abstract_gate("CNOT", (control_qubits[0], target)))
+        else:
+            gates.append(_make_abstract_gate("MCX", control_qubits + (target,)))
+        for control in reversed(zero_controls):
+            gates.append(_make_abstract_gate("X", (control,)))
+        return gates
+
+    def _pysparq_two_qubit_state_prep_gates(
+        self,
+        qubits: tuple[int, int],
+        values: list[float],
+        base_controls: tuple[tuple[int, int], ...],
+    ) -> list:
+        """Match PySparQ's 2-qubit Rot_GeneralStatePrep unitary."""
+        q0, q1 = qubits
+        gates = []
+        residual = 1.0
+        angles = []
+        for value in values[1:]:
+            if residual < 1e-15:
+                angles.append(0.0)
+                continue
+            sine = max(-1.0, min(1.0, value / residual))
+            angles.append(2 * math.asin(sine))
+            residual *= math.sqrt(max(0.0, 1.0 - sine * sine))
+
+        gates.extend(self._controlled_ry_gates(
+            q0, angles[0], base_controls + ((q1, 0),)
+        ))
+        gates.extend(self._controlled_ry_gates(
+            q1, angles[1], base_controls + ((q0, 0),)
+        ))
+        gates.extend(self._controlled_x_gates(q0, base_controls + ((q1, 1),)))
+        gates.extend(self._controlled_ry_gates(
+            q1, angles[2], base_controls + ((q0, 0),)
+        ))
+        gates.extend(self._controlled_x_gates(q0, base_controls + ((q1, 1),)))
+        return gates
+
+    def _real_state_prep_gates(
+        self,
+        qubits: tuple[int, ...],
+        state_vector: list[complex],
+        base_controls: tuple[tuple[int, int], ...] = (),
+    ) -> list:
+        """Synthesize real-amplitude state prep in little-endian order.
+
+        The vector index is interpreted as the integer encoded by ``qubits``,
+        with ``qubits[0]`` the least significant bit.  This covers the
+        tridiagonal block-encoding state-prep path and avoids the older
+        low-bit-first approximation.
+        """
+        values = [float(complex(value).real) for value in state_vector]
+        if len(values) != 1 << len(qubits):
+            raise UnsupportedQECPrimitive(
+                f"State vector of length {len(values)} does not match "
+                f"{len(qubits)} QEC qubits."
+            )
+        norm = math.sqrt(sum(value * value for value in values))
+        if norm < 1e-15:
+            return []
+        values = [value / norm for value in values]
+        if len(qubits) == 2:
+            return self._pysparq_two_qubit_state_prep_gates(
+                (qubits[0], qubits[1]), values, tuple(base_controls)
+            )
+        gates = []
+
+        def recurse(active_qubits: tuple[int, ...], vec: list[float],
+                    controls: tuple[tuple[int, int], ...] = ()) -> None:
+            if not active_qubits:
+                return
+            if len(active_qubits) == 1:
+                angle = 2 * math.atan2(vec[1], vec[0])
+                gates.extend(self._controlled_ry_gates(active_qubits[0], angle, controls))
+                return
+
+            target = active_qubits[-1]
+            half = len(vec) // 2
+            low = vec[:half]
+            high = vec[half:]
+            low_norm = math.sqrt(sum(value * value for value in low))
+            high_norm = math.sqrt(sum(value * value for value in high))
+            angle = 2 * math.atan2(high_norm, low_norm)
+            gates.extend(self._controlled_ry_gates(target, angle, controls))
+
+            rest = active_qubits[:-1]
+            if low_norm > 1e-15:
+                recurse(rest, [value / low_norm for value in low], controls + ((target, 0),))
+            if high_norm > 1e-15:
+                recurse(rest, [value / high_norm for value in high], controls + ((target, 1),))
+
+        recurse(tuple(qubits), values, tuple(base_controls))
+        return gates
 
     def _value_control_zero_qubits(self, controllers_ctx: dict) -> tuple[int, ...]:
         """Qubits that must be X-sandwiched for conditioned_by_value controls."""
@@ -370,8 +550,10 @@ class QECLoweringVisitor:
         if not main or not subs or not self.alloc.has(main):
             return
 
-        # Split: create sub-register ranges from main's range.
-        # Keep main's full range intact (it's still referenced by later operations).
+        # PySparQ SplitRegister(first, second, size) cuts the low ``size``
+        # bits from ``first`` into ``second`` and right-shifts ``first``.
+        # Multiple sub-registers in a single pyqres SplitRegister are applied
+        # in order, so each subsequent sub-register receives the next low bits.
         main_start, main_size = self.alloc._ranges[main]
         offset = 0
         for sub, size in zip(subs, sizes):
@@ -379,6 +561,11 @@ class QECLoweringVisitor:
                 break
             self.alloc._ranges[sub] = (main_start + offset, size)
             offset += size
+        remaining = main_size - offset
+        if remaining > 0:
+            self.alloc._ranges[main] = (main_start + offset, remaining)
+        else:
+            self.alloc.free(main)
 
     def _handle_combine(self, node, dagger_ctx=False):
         main = node.reg_list[0] if node.reg_list else None
@@ -393,7 +580,16 @@ class QECLoweringVisitor:
             return
 
         if main and sub and self.alloc.has(sub):
-            self.regs.combine_register(main, sub)
+            sub_start, sub_size = self.alloc._ranges[sub]
+            if self.alloc.has(main):
+                main_start, main_size = self.alloc._ranges[main]
+                # CombineRegister(first, second) appends ``second`` back as
+                # the low bits, reversing the low-bit split above.
+                new_start = min(sub_start, main_start)
+                self.alloc._ranges[main] = (new_start, main_size + sub_size)
+            else:
+                self.alloc._ranges[main] = (sub_start, sub_size)
+            self.alloc.free(sub)
 
     # ---- Single-qubit gates ----
 
@@ -583,7 +779,14 @@ class QECLoweringVisitor:
         for reg in node.control_regs:
             ctrl_qubits.extend(self.alloc.qubit_range(reg))
         tgt_qubits = self.alloc.qubit_range(node.target_reg)
-        self._emit_gate("MCX", tuple(ctrl_qubits) + (tgt_qubits[0],))
+        extra_ctrl_qubits, zero_qubits = self._controller_qubits(controllers_ctx)
+        extra_ctrl_qubits = tuple(q for q in extra_ctrl_qubits if q != tgt_qubits[0])
+        all_controls = tuple(extra_ctrl_qubits) + tuple(ctrl_qubits)
+
+        def emit():
+            self._emit_gate("MCX", all_controls + (tgt_qubits[0],))
+
+        self._emit_with_value_control_sandwich(zero_qubits, emit)
 
     def _lower_ADD(self, node, dagger_ctx, controllers_ctx):
         """N-bit ripple-carry adder: |a>|b> -> |a>|(a+b mod 2^n)>.
@@ -598,18 +801,43 @@ class QECLoweringVisitor:
         carry_q = self.alloc.allocate_anonymous(n)
         maj_q = self.alloc.allocate_anonymous(n)
         temp_q = self.alloc.allocate_anonymous(n)
-        self._emit_gate(
-            "ADD",
-            tuple(carry_q) + tuple(a_q) + tuple(b_q) + tuple(maj_q) + tuple(temp_q),
-            (n,),
-        )
+        ctrl_qubits, zero_qubits = self._controller_qubits(controllers_ctx)
+        add_qubits = tuple(carry_q) + tuple(a_q) + tuple(b_q) + tuple(maj_q) + tuple(temp_q)
+        ctrl_qubits = tuple(q for q in ctrl_qubits if q not in set(add_qubits))
+        effective_dagger = node.dagger_flag ^ dagger_ctx
+        gate_name = "ADD_DAG" if effective_dagger else "ADD"
+        params = (n,)
+        qubits = add_qubits
+        if ctrl_qubits:
+            gate_name = "CADD_DAG" if effective_dagger else "CADD"
+            params = (n, len(ctrl_qubits))
+            qubits = tuple(ctrl_qubits) + add_qubits
+
+        def emit():
+            self._emit_gate(gate_name, qubits, params)
+
+        self._emit_with_value_control_sandwich(zero_qubits, emit)
 
     def _lower_PLUS_ONE(self, node, dagger_ctx, controllers_ctx):
         """Increment circuit: |r> → |r+1 mod 2^n>."""
         main_q = list(self.alloc.qubit_range(node.main_reg))
         overflow_q = list(self.alloc.qubit_range(node.overflow_reg)) if node.overflow_reg else []
-        all_q = main_q + overflow_q
-        self._emit_gate("PLUS_ONE", tuple(all_q), (node.n_bits,))
+        all_q = tuple(main_q + overflow_q)
+        ctrl_qubits, zero_qubits = self._controller_qubits(controllers_ctx)
+        ctrl_qubits = tuple(q for q in ctrl_qubits if q not in set(all_q))
+        effective_dagger = node.dagger_flag ^ dagger_ctx
+        gate_name = "PLUS_ONE_DAG" if effective_dagger else "PLUS_ONE"
+        params = (node.n_bits,)
+        qubits = all_q
+        if ctrl_qubits:
+            gate_name = "CPLUS_ONE_DAG" if effective_dagger else "CPLUS_ONE"
+            params = (node.n_bits, len(ctrl_qubits))
+            qubits = tuple(ctrl_qubits) + all_q
+
+        def emit():
+            self._emit_gate(gate_name, qubits, params)
+
+        self._emit_with_value_control_sandwich(zero_qubits, emit)
 
     def _lower_REFLECT(self, node, dagger_ctx, controllers_ctx):
         """Multi-controlled Z (reflection)."""
@@ -617,7 +845,7 @@ class QECLoweringVisitor:
         for reg in node.target_regs:
             qubits.extend(self.alloc.qubit_range(reg))
         n_bits = len(qubits)
-        self._emit_gate("REFLECT", tuple(qubits), (n_bits,))
+        self._emit_controlled_gate("REFLECT", tuple(qubits), (n_bits,), controllers_ctx)
 
     def _lower_MOD_ADD(self, node, dagger_ctx, controllers_ctx):
         """Modular addition: |a>|b> → |a>|a+b mod N>.
@@ -628,8 +856,22 @@ class QECLoweringVisitor:
         a_q = list(self.alloc.qubit_range(node.a_reg))
         b_q = list(self.alloc.qubit_range(node.b_reg))
         flag_q = self.alloc.allocate_anonymous(1)
-        all_q = a_q + b_q + flag_q
-        self._emit_gate("MOD_ADD", tuple(all_q), (node.modulus,))
+        all_q = tuple(a_q + b_q + flag_q)
+        ctrl_qubits, zero_qubits = self._controller_qubits(controllers_ctx)
+        ctrl_qubits = tuple(q for q in ctrl_qubits if q not in set(all_q))
+        effective_dagger = node.dagger_flag ^ dagger_ctx
+        gate_name = "MOD_SUB" if effective_dagger else "MOD_ADD"
+        params = (node.modulus,)
+        qubits = all_q
+        if ctrl_qubits:
+            gate_name = "CMOD_SUB" if effective_dagger else "CMOD_ADD"
+            params = (node.modulus, len(ctrl_qubits))
+            qubits = tuple(ctrl_qubits) + all_q
+
+        def emit():
+            self._emit_gate(gate_name, qubits, params)
+
+        self._emit_with_value_control_sandwich(zero_qubits, emit)
 
     def _lower_MOD_MUL(self, node, dagger_ctx, controllers_ctx):
         """Modular multiplication: |reg> → |reg * c mod N>.
@@ -640,8 +882,26 @@ class QECLoweringVisitor:
         reg_q = list(self.alloc.qubit_range(node.reg))
         work_q = self.alloc.allocate_anonymous(len(reg_q))
         flag_q = self.alloc.allocate_anonymous(1)
-        all_q = reg_q + work_q + flag_q
-        self._emit_gate("MOD_MUL", tuple(all_q), (float(node.multiplier), float(node.modulus)))
+        all_q = tuple(reg_q + work_q + flag_q)
+        multiplier = int(node.multiplier)
+        modulus = int(node.modulus)
+        ctrl_qubits, zero_qubits = self._controller_qubits(controllers_ctx)
+        ctrl_qubits = tuple(q for q in ctrl_qubits if q not in set(all_q))
+        effective_dagger = node.dagger_flag ^ dagger_ctx
+        if effective_dagger:
+            multiplier = pow(multiplier, -1, modulus)
+        gate_name = "MOD_MUL"
+        params = (float(multiplier), float(modulus))
+        qubits = all_q
+        if ctrl_qubits:
+            gate_name = "CMOD_MUL"
+            params = (float(multiplier), float(modulus), float(len(ctrl_qubits)))
+            qubits = tuple(ctrl_qubits) + all_q
+
+        def emit():
+            self._emit_gate(gate_name, qubits, params)
+
+        self._emit_with_value_control_sandwich(zero_qubits, emit)
 
     # ---- Transform operations ----
 
@@ -700,9 +960,23 @@ class QECLoweringVisitor:
         overflow_reg = node.reg_list[1] if len(node.reg_list) > 1 else None
         if not main_reg or not overflow_reg:
             return
-        qubits = self.alloc.qubit_range(main_reg) + self.alloc.qubit_range(overflow_reg)
+        qubits = tuple(self.alloc.qubit_range(main_reg) + self.alloc.qubit_range(overflow_reg))
         n_bits = len(self.alloc.qubit_range(main_reg))
-        self._emit_controlled_gate("PLUS_ONE", tuple(qubits), (n_bits,), controllers_ctx)
+        ctrl_qubits, zero_qubits = self._controller_qubits(controllers_ctx)
+        ctrl_qubits = tuple(q for q in ctrl_qubits if q not in set(qubits))
+        effective_dagger = node.dagger_flag ^ dagger_ctx
+        gate_name = "PLUS_ONE_DAG" if effective_dagger else "PLUS_ONE"
+        params = (n_bits,)
+        all_qubits = qubits
+        if ctrl_qubits:
+            gate_name = "CPLUS_ONE_DAG" if effective_dagger else "CPLUS_ONE"
+            params = (n_bits, len(ctrl_qubits))
+            all_qubits = tuple(ctrl_qubits) + qubits
+
+        def emit():
+            self._emit_gate(gate_name, all_qubits, params)
+
+        self._emit_with_value_control_sandwich(zero_qubits, emit)
 
     # ---- Arithmetic: ExpMod / ModMul (Shor) ----
 
@@ -749,11 +1023,31 @@ class QECLoweringVisitor:
 
         qubits = self.alloc.qubit_range(reg)
         n_qubits = len(qubits)
+        effective_dagger = node.dagger_flag ^ dagger_ctx
+
+        if _is_real_state_vector(state_vector):
+            ctrl_qubits, zero_qubits = self._controller_qubits(controllers_ctx)
+            target_set = set(qubits)
+            zero_set = set(zero_qubits)
+            base_controls = tuple(
+                (q, 0 if q in zero_set else 1)
+                for q in ctrl_qubits
+                if q not in target_set
+            )
+            gates = self._real_state_prep_gates(qubits, state_vector, base_controls)
+            if effective_dagger:
+                gates = [
+                    _make_abstract_gate(g.name, g.qubits, tuple(-p for p in g.params))
+                    if g.name == "RY" else g
+                    for g in reversed(gates)
+                ]
+            self.gates.extend(gates)
+            return
 
         rotations = _state_prep_to_rotations(state_vector, n_qubits)
 
         # If dagger, reverse the rotation sequence and negate angles
-        if dagger_ctx:
+        if effective_dagger:
             rotations = list(reversed(rotations))
             for r in rotations:
                 r["angle"] = -r["angle"]
@@ -820,7 +1114,7 @@ class QECLoweringVisitor:
                                controllers_ctx: dict = None):
         """Emit a gate, wrapping with controls if needed."""
         controllers_ctx = controllers_ctx or {}
-        ctrl_qubits = self._apply_controllers((), controllers_ctx)
+        ctrl_qubits, zero_qubits = self._controller_qubits(controllers_ctx)
 
         # Filter out control qubits that overlap with target (from register-level
         # conditioning where target register is sub-register of control register)
@@ -828,9 +1122,26 @@ class QECLoweringVisitor:
         ctrl_qubits = [q for q in ctrl_qubits if q not in target_set]
 
         if not ctrl_qubits:
-            self._emit_gate(name, base_qubits, params)
+            def emit_uncontrolled():
+                self._emit_gate(name, base_qubits, params)
+
+            self._emit_with_value_control_sandwich(zero_qubits, emit_uncontrolled)
             return
 
+        def emit_controlled():
+            self._emit_controlled_gate_no_value_sandwich(
+                name, base_qubits, params, tuple(ctrl_qubits)
+            )
+
+        self._emit_with_value_control_sandwich(zero_qubits, emit_controlled)
+
+    def _emit_controlled_gate_no_value_sandwich(
+        self,
+        name: str,
+        base_qubits: tuple[int, ...],
+        params: tuple[float, ...],
+        ctrl_qubits: tuple[int, ...],
+    ):
         if name in ("H", "X", "Y", "Z"):
             # Single-qubit gate with controls → MCX variant
             all_qubits = tuple(ctrl_qubits) + base_qubits

--- a/pyqres/dsl/schemas/primitives/intermediate.primitive.yaml
+++ b/pyqres/dsl/schemas/primitives/intermediate.primitive.yaml
@@ -1,0 +1,9 @@
+name: intermediate
+description: Intermediate primitives for QEC-compiler integration. These map directly to AbstractGate names and are decomposed inside QEC-compiler's pipeline.
+primitives:
+  - MCX
+  - ADD
+  - MOD_ADD
+  - MOD_MUL
+  - PLUS_ONE
+  - REFLECT

--- a/pyqres/primitives/__init__.py
+++ b/pyqres/primitives/__init__.py
@@ -48,6 +48,9 @@ from .measurement import (
 
 from .debug import DebugPrimitive, CheckNan, CheckNormalization
 
+# Intermediate / QEC-compiler layer
+from .intermediate import MCX, ADD, PLUS_ONE, REFLECT, MOD_ADD, MOD_MUL
+
 __all__ = [
     # Gates
     "Hadamard", "Hadamard_NDigits",
@@ -89,4 +92,7 @@ __all__ = [
     "Prob", "StatePrint",
     # Debug
     "DebugPrimitive", "CheckNan", "CheckNormalization",
+    # Intermediate / QEC-compiler layer
+    "MCX", "ADD", "PLUS_ONE", "REFLECT",
+    "MOD_ADD", "MOD_MUL",
 ]

--- a/pyqres/primitives/intermediate.py
+++ b/pyqres/primitives/intermediate.py
@@ -100,6 +100,7 @@ class PLUS_ONE(Primitive):
         else:
             obj = PyQSparseOperationWrapper(
                 ps.PlusOneAndOverflow(self.main_reg, "_overflow"))
+        obj.set_dagger(dagger_ctx ^ self.dagger_flag)
         obj.set_controller(controllers_ctx)
         return obj
 
@@ -158,13 +159,10 @@ class MOD_ADD(Primitive):
         self.modulus = param_list[0] if param_list else 2
 
     def pyqsparse_object(self, dagger_ctx=False, controllers_ctx=None):
-        import pysparq as ps
-        controllers_ctx = merge_controllers(self.controllers, controllers_ctx or {})
-        obj = PyQSparseOperationWrapper(
-            ps.Add_UInt_UInt_InPlace(self.a_reg, self.b_reg))
-        obj.set_dagger(dagger_ctx)
-        obj.set_controller(controllers_ctx)
-        return obj
+        raise NotImplementedError(
+            "MOD_ADD has no matching PySparQ reference primitive yet. "
+            "Using Add_UInt_UInt_InPlace would violate the modular-add contract."
+        )
 
     def t_count(self, dagger_ctx=False, controllers_ctx=None):
         n = reg_sz(self.a_reg) if self.a_reg else 1
@@ -186,9 +184,24 @@ class MOD_MUL(Primitive):
 
     def pyqsparse_object(self, dagger_ctx=False, controllers_ctx=None):
         import pysparq as ps
+        import math
         controllers_ctx = merge_controllers(self.controllers, controllers_ctx or {})
+        multiplier = int(self.multiplier)
+        modulus = int(self.modulus)
+        if math.gcd(multiplier, modulus) != 1:
+            raise ValueError(
+                f"MOD_MUL requires multiplier coprime to modulus, got "
+                f"multiplier={multiplier}, modulus={modulus}"
+            )
+        if dagger_ctx ^ self.dagger_flag:
+            multiplier = pow(multiplier, -1, modulus)
+        op_cls = getattr(ps, "Mod_Mult_UInt_ConstUInt_InPlace", None)
+        if op_cls is None:
+            op_cls = getattr(ps, "Mod_Mult_UInt_ConstUInt")
+        # PySparQ's primitive computes reg *= a^(2^x) mod N.  Use x=0 so
+        # the multiplier is exactly the intermediate-layer constant c.
         obj = PyQSparseOperationWrapper(
-            ps.Mod_Mult_UInt_ConstUInt(self.reg, self.multiplier, 0, self.modulus))
+            op_cls(self.reg, multiplier, 0, modulus))
         obj.set_controller(controllers_ctx)
         return obj
 

--- a/pyqres/primitives/intermediate.py
+++ b/pyqres/primitives/intermediate.py
@@ -1,0 +1,204 @@
+"""Intermediate primitives for QEC-compiler integration.
+
+These Primitive subclasses map directly to QEC-compiler AbstractGate names.
+Each implements:
+- to_abstract_gates(): returns AbstractGate list for QEC lowering
+- pyqsparse_object(): decomposed PySparQ simulation for verification
+- t_count(): resource estimation
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..core.operation import Primitive
+from ..core.utils import get_control_qubit_count, merge_controllers, reg_sz, mcx_t_count
+from ..core.simulator import PyQSparseOperationWrapper
+
+
+def _lazy_abstract_gate(name: str, qubits: tuple[int, ...], params: tuple[float, ...] = ()):
+    from qec_compiler.ir import AbstractGate
+    return AbstractGate(name=name, qubits=qubits, params=params)
+
+
+class MCX(Primitive):
+    """Multi-controlled X gate. Maps directly to AbstractGate('MCX')."""
+
+    def __init__(self, reg_list=None, param_list=None):
+        super().__init__(reg_list=reg_list, param_list=param_list)
+        self.control_regs = reg_list[:-1] if reg_list else []
+        self.target_reg = reg_list[-1] if reg_list else None
+
+    def pyqsparse_object(self, dagger_ctx=False, controllers_ctx=None):
+        import pysparq as ps
+        controllers_ctx = merge_controllers(self.controllers, controllers_ctx or {})
+        obj = PyQSparseOperationWrapper(ps.FlipBools(self.target_reg))
+        obj.set_controller(controllers_ctx)
+        return obj
+
+    def t_count(self, dagger_ctx=False, controllers_ctx=None):
+        ncontrols = get_control_qubit_count(
+            merge_controllers(self.controllers, controllers_ctx or {}))
+        n_controls_intrinsic = sum(reg_sz(r) for r in self.control_regs)
+        return mcx_t_count(n_controls_intrinsic + ncontrols)
+
+    def to_abstract_gates(self, qubit_map):
+        ctrl_qubits = []
+        for reg in self.control_regs:
+            ctrl_qubits.extend(qubit_map[reg])
+        tgt_qubits = qubit_map[self.target_reg]
+        return [_lazy_abstract_gate("MCX", tuple(ctrl_qubits) + (tgt_qubits[0],))]
+
+
+class ADD(Primitive):
+    """N-bit ripple-carry adder. Maps to AbstractGate('ADD', (n_bits,))."""
+
+    def __init__(self, reg_list=None, param_list=None):
+        super().__init__(reg_list=reg_list, param_list=param_list)
+        self.input_reg1 = reg_list[0] if reg_list else None
+        self.input_reg2 = reg_list[1] if len(reg_list) > 1 else None
+        self.n_bits = param_list[0] if param_list else reg_sz(self.input_reg1) if self.input_reg1 else 1
+
+    def pyqsparse_object(self, dagger_ctx=False, controllers_ctx=None):
+        import pysparq as ps
+        controllers_ctx = merge_controllers(self.controllers, controllers_ctx or {})
+        obj = PyQSparseOperationWrapper(
+            ps.Add_UInt_UInt_InPlace(self.input_reg1, self.input_reg2))
+        obj.set_dagger(dagger_ctx)
+        obj.set_controller(controllers_ctx)
+        return obj
+
+    def t_count(self, dagger_ctx=False, controllers_ctx=None):
+        ncontrols = get_control_qubit_count(
+            merge_controllers(self.controllers, controllers_ctx or {}))
+        n = self.n_bits
+        return 2 * (n - 1) * mcx_t_count(ncontrols + 2)
+
+    def to_abstract_gates(self, qubit_map):
+        a_qubits = qubit_map[self.input_reg1]
+        b_qubits = qubit_map[self.input_reg2]
+        return [_lazy_abstract_gate("ADD", tuple(a_qubits) + tuple(b_qubits), (self.n_bits,))]
+
+
+class PLUS_ONE(Primitive):
+    """Increment circuit. Maps to AbstractGate('PLUS_ONE', (n_bits,))."""
+
+    def __init__(self, reg_list=None, param_list=None):
+        super().__init__(reg_list=reg_list, param_list=param_list)
+        self.main_reg = reg_list[0] if reg_list else None
+        self.overflow_reg = reg_list[1] if len(reg_list) > 1 else None
+        self.n_bits = param_list[0] if param_list else reg_sz(self.main_reg) if self.main_reg else 1
+
+    __self_conjugate__ = False
+
+    def pyqsparse_object(self, dagger_ctx=False, controllers_ctx=None):
+        import pysparq as ps
+        controllers_ctx = merge_controllers(self.controllers, controllers_ctx or {})
+        if self.overflow_reg:
+            obj = PyQSparseOperationWrapper(
+                ps.PlusOneAndOverflow(self.main_reg, self.overflow_reg))
+        else:
+            obj = PyQSparseOperationWrapper(
+                ps.PlusOneAndOverflow(self.main_reg, "_overflow"))
+        obj.set_controller(controllers_ctx)
+        return obj
+
+    def t_count(self, dagger_ctx=False, controllers_ctx=None):
+        ncontrols = get_control_qubit_count(
+            merge_controllers(self.controllers, controllers_ctx or {}))
+        n = self.n_bits
+        return 4 * n + ncontrols * 4
+
+    def to_abstract_gates(self, qubit_map):
+        qubits = list(qubit_map[self.main_reg])
+        if self.overflow_reg and self.overflow_reg in qubit_map:
+            qubits.extend(qubit_map[self.overflow_reg])
+        return [_lazy_abstract_gate("PLUS_ONE", tuple(qubits), (self.n_bits,))]
+
+
+class REFLECT(Primitive):
+    """Multi-controlled Z (reflection). Maps to AbstractGate('REFLECT', (n_bits,))."""
+
+    __self_conjugate__ = True
+
+    def __init__(self, reg_list=None, param_list=None):
+        super().__init__(reg_list=reg_list, param_list=param_list)
+        self.target_regs = reg_list
+
+    def pyqsparse_object(self, dagger_ctx=False, controllers_ctx=None):
+        import pysparq as ps
+        controllers_ctx = merge_controllers(self.controllers, controllers_ctx or {})
+        inverse = param_list[0] if (param_list := self.param_list) else True
+        obj = PyQSparseOperationWrapper(
+            ps.Reflection_Bool(self.target_regs, inverse))
+        obj.set_controller(controllers_ctx)
+        return obj
+
+    def t_count(self, dagger_ctx=False, controllers_ctx=None):
+        ncontrols = get_control_qubit_count(
+            merge_controllers(self.controllers, controllers_ctx or {}))
+        n = sum(reg_sz(r) for r in self.target_regs)
+        return mcx_t_count(n + ncontrols)
+
+    def to_abstract_gates(self, qubit_map):
+        qubits = []
+        for reg in self.target_regs:
+            qubits.extend(qubit_map[reg])
+        n_bits = len(qubits)
+        return [_lazy_abstract_gate("REFLECT", tuple(qubits), (n_bits,))]
+
+
+class MOD_ADD(Primitive):
+    """Modular addition a+b mod N. Maps to AbstractGate('MOD_ADD', (modulus,))."""
+
+    def __init__(self, reg_list=None, param_list=None):
+        super().__init__(reg_list=reg_list, param_list=param_list)
+        self.a_reg = reg_list[0] if reg_list else None
+        self.b_reg = reg_list[1] if len(reg_list) > 1 else None
+        self.modulus = param_list[0] if param_list else 2
+
+    def pyqsparse_object(self, dagger_ctx=False, controllers_ctx=None):
+        import pysparq as ps
+        controllers_ctx = merge_controllers(self.controllers, controllers_ctx or {})
+        obj = PyQSparseOperationWrapper(
+            ps.Add_UInt_UInt_InPlace(self.a_reg, self.b_reg))
+        obj.set_dagger(dagger_ctx)
+        obj.set_controller(controllers_ctx)
+        return obj
+
+    def t_count(self, dagger_ctx=False, controllers_ctx=None):
+        n = reg_sz(self.a_reg) if self.a_reg else 1
+        return 4 * n * 2  # Approximate: add + compare + conditional sub
+
+    def to_abstract_gates(self, qubit_map):
+        qubits = list(qubit_map[self.a_reg]) + list(qubit_map[self.b_reg])
+        return [_lazy_abstract_gate("MOD_ADD", tuple(qubits), (self.modulus,))]
+
+
+class MOD_MUL(Primitive):
+    """Modular multiplication a*c mod N. Maps to AbstractGate('MOD_MUL', (multiplier, modulus))."""
+
+    def __init__(self, reg_list=None, param_list=None):
+        super().__init__(reg_list=reg_list, param_list=param_list)
+        self.reg = reg_list[0] if reg_list else None
+        self.multiplier = param_list[0] if param_list else 1
+        self.modulus = param_list[1] if len(param_list) > 1 else 2
+
+    def pyqsparse_object(self, dagger_ctx=False, controllers_ctx=None):
+        import pysparq as ps
+        controllers_ctx = merge_controllers(self.controllers, controllers_ctx or {})
+        obj = PyQSparseOperationWrapper(
+            ps.Mod_Mult_UInt_ConstUInt(self.reg, self.multiplier, 0, self.modulus))
+        obj.set_controller(controllers_ctx)
+        return obj
+
+    def t_count(self, dagger_ctx=False, controllers_ctx=None):
+        n = reg_sz(self.reg) if self.reg else 1
+        ncontrols = get_control_qubit_count(
+            merge_controllers(self.controllers, controllers_ctx or {}))
+        return 4 * n * mcx_t_count(ncontrols + 2)
+
+    def to_abstract_gates(self, qubit_map):
+        qubits = list(qubit_map[self.reg])
+        return [_lazy_abstract_gate("MOD_MUL", tuple(qubits),
+                                    (self.multiplier, self.modulus))]

--- a/pyqres/visualization/__init__.py
+++ b/pyqres/visualization/__init__.py
@@ -1,0 +1,17 @@
+"""HTML visualizations for pyqres operation trees and circuits."""
+
+from .html import (
+    operation_to_tree_data,
+    render_call_tree_html,
+    render_circuit_html,
+    write_call_tree_html,
+    write_circuit_html,
+)
+
+__all__ = [
+    "operation_to_tree_data",
+    "render_call_tree_html",
+    "render_circuit_html",
+    "write_call_tree_html",
+    "write_circuit_html",
+]

--- a/pyqres/visualization/html.py
+++ b/pyqres/visualization/html.py
@@ -1,0 +1,565 @@
+"""Self-contained HTML visualizations for pyqres operations.
+
+The Python side exports a structural JSON model.  The browser handles
+expand/collapse state and circuit redraws, so generated HTML files are static
+and do not need a local server.
+"""
+
+from __future__ import annotations
+
+from html import escape
+import json
+from pathlib import Path
+from typing import Any
+
+from pyqres.core.metadata import RegisterMetadata
+from pyqres.core.operation import Primitive
+from pyqres.core.utils import merge_controllers
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, complex):
+        return {"real": value.real, "imag": value.imag}
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _json_value(val) for key, val in value.items()}
+    if hasattr(value, "__name__"):
+        return value.__name__
+    return repr(value)
+
+
+def _controller_data(controllers: dict) -> dict:
+    return {name: _json_value(items) for name, items in controllers.items() if items}
+
+
+def _controller_registers(controllers: dict) -> list[str]:
+    regs = []
+    for items in controllers.values():
+        for item in items:
+            if isinstance(item, dict):
+                regs.extend(str(reg) for reg in item.keys())
+            elif isinstance(item, tuple):
+                regs.append(str(item[0]))
+            else:
+                regs.append(str(item))
+    return regs
+
+
+def _node_registers(node) -> list[str]:
+    regs = [str(reg) for reg in getattr(node, "reg_list", [])]
+    regs.extend(str(reg) for reg, _size in getattr(node, "temp_reg_list", []))
+    return regs
+
+
+def operation_to_tree_data(operation) -> dict:
+    """Return a JSON-serializable operation tree model."""
+    counter = {"value": 0}
+    metadata = RegisterMetadata.get_register_metadata()
+    register_size_hints = {str(name): str(size) for name, size in metadata.registers.items()}
+    register_type_hints = {
+        str(name): metadata.register_types.get(name, "General")
+        for name in metadata.registers
+    }
+    registers = [
+        {
+            "name": str(name),
+            "size": str(size),
+            "type": metadata.register_types.get(name, "General"),
+        }
+        for name, size in metadata.registers.items()
+    ]
+
+    def next_id() -> str:
+        counter["value"] += 1
+        return f"n{counter['value']}"
+
+    def record_register_hints(node) -> None:
+        for reg, size in getattr(node, "temp_reg_list", []):
+            register_size_hints.setdefault(str(reg), str(size))
+            register_type_hints.setdefault(str(reg), "General")
+
+        class_name = node.__class__.__name__
+        if class_name == "SplitRegister":
+            for reg, size in zip(getattr(node, "reg_list", [])[1:], getattr(node, "param_list", [])):
+                register_size_hints[str(reg)] = str(size)
+                register_type_hints.setdefault(str(reg), "General")
+        elif class_name in ("AddRegister", "AddRegisterWithHadamard") and len(getattr(node, "param_list", [])) >= 3:
+            reg, reg_type, size = node.param_list[:3]
+            register_size_hints[str(reg)] = str(size)
+            register_type_hints[str(reg)] = str(reg_type)
+
+    def build(node, dagger_ctx=False, controllers_ctx=None, depth=0, path="0"):
+        controllers_ctx = controllers_ctx or {}
+        record_register_hints(node)
+        node_id = next_id()
+        merged_controllers = merge_controllers(controllers_ctx, getattr(node, "controllers", {}))
+        effective_dagger = bool(getattr(node, "dagger_flag", False) ^ dagger_ctx)
+        children_dagger = effective_dagger
+        if node.is_self_conjugate():
+            children_dagger = False
+
+        program_list = list(getattr(node, "program_list", []))
+        if isinstance(node, Primitive):
+            program_list = []
+        elif children_dagger:
+            program_list = list(reversed(program_list))
+
+        children = [
+            build(child, children_dagger, merged_controllers, depth + 1, f"{path}.{idx}")
+            for idx, child in enumerate(program_list)
+        ]
+
+        kind = "primitive" if isinstance(node, Primitive) else "composite"
+        if node.__class__.__name__ in ("SplitRegister", "CombineRegister", "AddRegister", "RemoveRegister"):
+            kind = "register"
+
+        return {
+            "id": node_id,
+            "path": path,
+            "name": node.name,
+            "kind": kind,
+            "depth": depth,
+            "registers": _node_registers(node),
+            "registerSizes": {
+                reg: register_size_hints.get(reg, "?")
+                for reg in _node_registers(node)
+            },
+            "params": _json_value(getattr(node, "param_list", [])),
+            "submodules": _json_value(getattr(node, "submodules", [])),
+            "controllers": _controller_data(merged_controllers),
+            "controllerRegisters": _controller_registers(merged_controllers),
+            "dagger": effective_dagger,
+            "children": children,
+        }
+
+    tree = build(operation)
+    register_names = {reg["name"] for reg in registers}
+
+    def collect_regs(node):
+        for reg in node["registers"] + node["controllerRegisters"]:
+            if reg not in register_names:
+                register_names.add(reg)
+                registers.append({
+                    "name": reg,
+                    "size": register_size_hints.get(reg, "?"),
+                    "type": register_type_hints.get(reg, "Unknown"),
+                })
+        for child in node["children"]:
+            collect_regs(child)
+
+    collect_regs(tree)
+    return {"root": tree, "registers": registers}
+
+
+def render_call_tree_html(operation, title: str | None = None) -> str:
+    """Render an expandable operation call tree as a standalone HTML page."""
+    data = operation_to_tree_data(operation)
+    page_title = title or f"{operation.name} call tree"
+    return _render_html(page_title, data, mode="tree")
+
+
+def render_circuit_html(operation, title: str | None = None) -> str:
+    """Render an interactive register-level circuit as standalone HTML."""
+    data = operation_to_tree_data(operation)
+    page_title = title or f"{operation.name} circuit"
+    return _render_html(page_title, data, mode="circuit")
+
+
+def write_call_tree_html(operation, path: str | Path, title: str | None = None) -> Path:
+    """Write an expandable operation call tree HTML file."""
+    output = Path(path)
+    output.write_text(render_call_tree_html(operation, title), encoding="utf-8")
+    return output
+
+
+def write_circuit_html(operation, path: str | Path, title: str | None = None) -> Path:
+    """Write an interactive register-level circuit HTML file."""
+    output = Path(path)
+    output.write_text(render_circuit_html(operation, title), encoding="utf-8")
+    return output
+
+
+def _render_html(title: str, data: dict, mode: str) -> str:
+    data_json = json.dumps(data, ensure_ascii=False)
+    title_html = escape(title)
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{title_html}</title>
+  <style>
+    :root {{
+      --bg: #f7f8fb;
+      --panel: #ffffff;
+      --ink: #1f2937;
+      --muted: #667085;
+      --line: #d8dee9;
+      --accent: #2563eb;
+      --accent-soft: #dbeafe;
+      --gate: #eef4ff;
+      --gate-border: #7aa2f7;
+      --reg: #f8fafc;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }}
+    body {{
+      margin: 0;
+      color: var(--ink);
+      background: var(--bg);
+    }}
+    header {{
+      padding: 18px 24px;
+      border-bottom: 1px solid var(--line);
+      background: var(--panel);
+    }}
+    h1 {{
+      margin: 0;
+      font-size: 20px;
+      font-weight: 650;
+      letter-spacing: 0;
+    }}
+    main {{
+      display: grid;
+      grid-template-columns: 280px minmax(0, 1fr);
+      min-height: calc(100vh - 62px);
+    }}
+    aside {{
+      border-right: 1px solid var(--line);
+      background: var(--panel);
+      padding: 16px;
+      overflow: auto;
+    }}
+    section {{
+      padding: 18px;
+      overflow: auto;
+    }}
+    .control-group {{
+      margin-bottom: 18px;
+    }}
+    .control-group h2 {{
+      margin: 0 0 10px;
+      font-size: 13px;
+      text-transform: uppercase;
+      color: var(--muted);
+      letter-spacing: .04em;
+    }}
+    .module-row {{
+      display: grid;
+      grid-template-columns: 18px minmax(0, 1fr);
+      gap: 8px;
+      align-items: start;
+      margin: 7px 0;
+      font-size: 13px;
+    }}
+    .module-row span {{
+      overflow-wrap: anywhere;
+    }}
+    .muted {{
+      color: var(--muted);
+    }}
+    input[type="range"] {{
+      width: 100%;
+    }}
+    .tree-root {{
+      max-width: 1100px;
+    }}
+    details {{
+      margin: 6px 0 6px 16px;
+      border-left: 1px solid var(--line);
+      padding-left: 10px;
+    }}
+    details.root {{
+      margin-left: 0;
+      border-left: 0;
+      padding-left: 0;
+    }}
+    summary {{
+      cursor: pointer;
+      list-style: none;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-height: 30px;
+    }}
+    summary::-webkit-details-marker {{
+      display: none;
+    }}
+    .twisty {{
+      color: var(--accent);
+      width: 14px;
+      display: inline-block;
+    }}
+    details[open] > summary .twisty {{
+      transform: rotate(90deg);
+    }}
+    .node-name {{
+      font-weight: 620;
+    }}
+    .badge {{
+      border: 1px solid var(--line);
+      color: var(--muted);
+      padding: 2px 6px;
+      border-radius: 999px;
+      font-size: 11px;
+      background: #fff;
+    }}
+    .node-details {{
+      margin: 4px 0 10px 22px;
+      font-size: 12px;
+      color: var(--muted);
+      display: grid;
+      gap: 3px;
+    }}
+    .circuit-wrap {{
+      min-width: 720px;
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      overflow: auto;
+    }}
+    .circuit-grid {{
+      position: relative;
+      display: grid;
+      gap: 0;
+      padding: 14px 12px;
+      min-width: max-content;
+    }}
+    .reg-label {{
+      background: var(--reg);
+      border-right: 1px solid var(--line);
+      padding: 11px 12px;
+      font-size: 13px;
+      white-space: nowrap;
+      z-index: 2;
+    }}
+    .wire {{
+      align-self: center;
+      height: 1px;
+      background: var(--line);
+      z-index: 1;
+    }}
+    .gate {{
+      align-self: center;
+      justify-self: center;
+      min-width: 86px;
+      max-width: 116px;
+      min-height: 30px;
+      padding: 6px 8px;
+      border: 1px solid var(--gate-border);
+      background: var(--gate);
+      border-radius: 6px;
+      text-align: center;
+      font-size: 12px;
+      line-height: 1.2;
+      z-index: 3;
+      box-shadow: 0 1px 3px rgba(31, 41, 55, .08);
+      overflow-wrap: anywhere;
+    }}
+    .gate.composite {{
+      border-color: #16a34a;
+      background: #ecfdf3;
+    }}
+    .gate.register {{
+      border-color: #d97706;
+      background: #fff7ed;
+    }}
+    .vline {{
+      justify-self: center;
+      width: 1px;
+      background: var(--gate-border);
+      z-index: 2;
+    }}
+    .empty {{
+      padding: 20px;
+      color: var(--muted);
+    }}
+  </style>
+</head>
+<body>
+  <header><h1>{title_html}</h1></header>
+  <main>
+    <aside id="sidebar"></aside>
+    <section id="content"></section>
+  </main>
+  <script>
+    window.PYQRES_VIS_MODE = {json.dumps(mode)};
+    window.PYQRES_TREE_DATA = {data_json};
+  </script>
+  <script>
+    const data = window.PYQRES_TREE_DATA;
+    const mode = window.PYQRES_VIS_MODE;
+    const sidebar = document.getElementById('sidebar');
+    const content = document.getElementById('content');
+
+    function formatValue(value) {{
+      if (value === null || value === undefined) return '';
+      if (typeof value === 'object') return JSON.stringify(value);
+      return String(value);
+    }}
+
+    function collectCompositeNodes(node, out = []) {{
+      if (node.children && node.children.length) out.push(node);
+      for (const child of node.children || []) collectCompositeNodes(child, out);
+      return out;
+    }}
+
+    function allNodes(node, out = []) {{
+      out.push(node);
+      for (const child of node.children || []) allNodes(child, out);
+      return out;
+    }}
+
+    function involvedRegisters(node) {{
+      const regs = new Set([...(node.registers || []), ...(node.controllerRegisters || [])]);
+      for (const child of node.children || []) {{
+        for (const reg of involvedRegisters(child)) regs.add(reg);
+      }}
+      return Array.from(regs);
+    }}
+
+    function detailLines(node) {{
+      const lines = [];
+      if (node.registers?.length) lines.push(['registers', node.registers.join(', ')]);
+      if (node.controllerRegisters?.length) lines.push(['controllers', node.controllerRegisters.join(', ')]);
+      if (node.params?.length) lines.push(['params', formatValue(node.params)]);
+      if (Object.keys(node.controllers || {{}}).length) lines.push(['control detail', formatValue(node.controllers)]);
+      if (node.submodules?.length) lines.push(['submodules', formatValue(node.submodules)]);
+      return lines;
+    }}
+
+    function renderSidebar() {{
+      const composites = allNodes(data.root).filter(n => n.kind === 'composite');
+      let html = '<div class="control-group"><h2>View</h2>';
+      html += `<label class="module-row"><input type="radio" name="mode" value="tree" ${{mode === 'tree' ? 'checked' : ''}}><span>Call tree</span></label>`;
+      html += `<label class="module-row"><input type="radio" name="mode" value="circuit" ${{mode === 'circuit' ? 'checked' : ''}}><span>Register circuit</span></label>`;
+      html += '</div>';
+      html += '<div class="control-group"><h2>Expansion depth</h2><input id="depthSlider" type="range" min="0" max="12" value="1"><div class="muted">Depth: <span id="depthValue">1</span></div><div class="muted">0 keeps the root collapsed; each step expands one more module level.</div></div>';
+      html += '<div class="control-group"><h2>Expand modules</h2>';
+      if (!composites.length) {{
+        html += '<div class="muted">No composite modules with children.</div>';
+      }} else {{
+        for (const node of composites) {{
+          const label = node.id === data.root.id ? `${{node.path}} ${{escapeHtml(node.name)}} (root)` : `${{node.path}} ${{escapeHtml(node.name)}}`;
+          html += `<label class="module-row"><input type="checkbox" class="module-toggle" value="${{node.id}}"><span>${{label}}</span></label>`;
+        }}
+      }}
+      html += '</div>';
+      sidebar.innerHTML = html;
+      sidebar.querySelectorAll('input[name="mode"]').forEach(input => {{
+        input.addEventListener('change', () => render(input.value));
+      }});
+      sidebar.querySelectorAll('input').forEach(input => {{
+        if (input.name !== 'mode') input.addEventListener('input', () => render(currentMode()));
+      }});
+    }}
+
+    function currentMode() {{
+      return sidebar.querySelector('input[name="mode"]:checked')?.value || mode;
+    }}
+
+    function selectedDepth() {{
+      return Number(document.getElementById('depthSlider')?.value || 1);
+    }}
+
+    function selectedModules() {{
+      return new Set(Array.from(sidebar.querySelectorAll('.module-toggle:checked')).map(input => input.value));
+    }}
+
+    function escapeHtml(value) {{
+      return String(value).replace(/[&<>"']/g, ch => ({{'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}}[ch]));
+    }}
+
+    function renderTreeNode(node, root = false) {{
+      const details = detailLines(node).map(([k, v]) => `<div><strong>${{escapeHtml(k)}}:</strong> ${{escapeHtml(v)}}</div>`).join('');
+      const children = (node.children || []).map(child => renderTreeNode(child)).join('');
+      return `<details class="${{root ? 'root' : ''}}" open>
+        <summary><span class="twisty">&#9654;</span><span class="node-name">${{escapeHtml(node.name)}}${{node.dagger ? '&dagger;' : ''}}</span><span class="badge">${{node.kind}}</span><span class="badge">${{node.path}}</span></summary>
+        <div class="node-details">${{details}}</div>
+        ${{children}}
+      </details>`;
+    }}
+
+    function flattenCircuit(node, depth, expandById, maxDepth) {{
+      const hasChildren = node.children && node.children.length;
+      const canExpand = hasChildren && (expandById.has(node.id) || depth < maxDepth);
+      if (canExpand) {{
+        return node.children.flatMap(child => flattenCircuit(child, depth + 1, expandById, maxDepth));
+      }}
+      return [node];
+    }}
+
+    function registerOrder(ops) {{
+      const known = data.registers.map(reg => reg.name);
+      const seen = new Set();
+      const ordered = [];
+      for (const reg of known) {{
+        if (!seen.has(reg)) {{
+          seen.add(reg);
+          ordered.push(reg);
+        }}
+      }}
+      for (const op of ops) {{
+        for (const reg of [...(op.registers || []), ...(op.controllerRegisters || [])]) {{
+          if (!seen.has(reg)) {{
+            seen.add(reg);
+            ordered.push(reg);
+          }}
+        }}
+      }}
+      return ordered;
+    }}
+
+    function renderCircuit() {{
+      const depth = selectedDepth();
+      const expanded = selectedModules();
+      const ops = flattenCircuit(data.root, 0, expanded, depth);
+      const regs = registerOrder(ops);
+      document.getElementById('depthValue').textContent = String(depth);
+      if (!ops.length || !regs.length) {{
+        content.innerHTML = '<div class="empty">No circuit operations to render.</div>';
+        return;
+      }}
+      const rowIndex = new Map(regs.map((reg, idx) => [reg, idx + 1]));
+      const colWidth = 124;
+      const rowHeight = 44;
+      let html = `<div class="circuit-wrap"><div class="circuit-grid" style="grid-template-columns: 170px repeat(${{ops.length}}, ${{colWidth}}px); grid-template-rows: repeat(${{regs.length}}, ${{rowHeight}}px)">`;
+      regs.forEach((reg, idx) => {{
+        const meta = data.registers.find(item => item.name === reg) || {{}};
+        html += `<div class="reg-label" style="grid-column: 1; grid-row: ${{idx + 1}}">${{escapeHtml(reg)}}<span class="muted">[${{escapeHtml(meta.size || '?')}}]</span></div>`;
+        html += `<div class="wire" style="grid-column: 2 / ${{ops.length + 2}}; grid-row: ${{idx + 1}}"></div>`;
+      }});
+      ops.forEach((op, idx) => {{
+        const involved = involvedRegisters(op).filter(reg => rowIndex.has(reg));
+        if (!involved.length) return;
+        const rows = involved.map(reg => rowIndex.get(reg)).sort((a, b) => a - b);
+        const start = rows[0];
+        const span = rows[rows.length - 1] - rows[0] + 1;
+        const col = idx + 2;
+        const params = op.params?.length ? `\\nparams: ${{formatValue(op.params)}}` : '';
+        const controls = op.controllerRegisters?.length ? `\\ncontrols: ${{op.controllerRegisters.join(', ')}}` : '';
+        html += `<div class="vline" style="grid-column: ${{col}}; grid-row: ${{start}} / span ${{span}}"></div>`;
+        html += `<div class="gate ${{op.kind}}" title="${{escapeHtml(op.path + params + controls)}}" style="grid-column: ${{col}}; grid-row: ${{start}} / span ${{span}}">${{escapeHtml(op.name)}}${{op.dagger ? '<sup>&dagger;</sup>' : ''}}</div>`;
+      }});
+      html += '</div></div>';
+      content.innerHTML = html;
+    }}
+
+    function renderTree() {{
+      document.getElementById('depthValue').textContent = String(selectedDepth());
+      content.innerHTML = `<div class="tree-root">${{renderTreeNode(data.root, true)}}</div>`;
+    }}
+
+    function render(nextMode) {{
+      if (nextMode === 'circuit') renderCircuit();
+      else renderTree();
+    }}
+
+    renderSidebar();
+    render(mode);
+  </script>
+</body>
+</html>
+"""

--- a/tests/test_algorithms_e2e.py
+++ b/tests/test_algorithms_e2e.py
@@ -33,11 +33,17 @@ from pyqres.algorithms.qda_solver import (
 from pyqres.algorithms.qda_solver import BlockEncoding, StatePreparation
 from pysparq.algorithms.qda_solver import BlockEncodingHs, BlockEncodingHsPD, WalkS, LCU, Filtering
 
-# Import PySparQ solver functions (they use pysparq.algorithms internally)
-from pysparq.algorithms.cks_solver import (
-    cks_solve_v2,
-    ChebyshevPolynomialCoefficient as PS_Chebyshev,
-)
+# Import PySparQ solver functions (they use pysparq.algorithms internally).
+# Some packaged PySparQ builds do not expose cks_solve_v2; the only tests that
+# use it are skipped below, so keep collection robust across those builds.
+try:
+    from pysparq.algorithms.cks_solver import (
+        cks_solve_v2,
+        ChebyshevPolynomialCoefficient as PS_Chebyshev,
+    )
+except ImportError:
+    cks_solve_v2 = None
+    PS_Chebyshev = None
 from pysparq.algorithms.qda_solver import (
     compute_fs as ps_compute_fs,
     compute_rotation_matrix as ps_compute_rotation_matrix,

--- a/tests/test_block_encoding.py
+++ b/tests/test_block_encoding.py
@@ -52,7 +52,7 @@ class TestPlusOneOverflow:
         # PlusOneOverflow with cond_value=1 is NOT the same as cond_value=2
         assert getattr(PlusOneOverflow, '__self_conjugate__', True) is False
 
-    def test_dagger_flips_condition(self):
+    def test_dagger_marks_inverse_operation(self):
         from pyqres.core.metadata import RegisterMetadata
         RegisterMetadata.get_register_metadata().declare_register('main', 4)
         RegisterMetadata.get_register_metadata().declare_register('overflow', 1)
@@ -61,7 +61,8 @@ class TestPlusOneOverflow:
             reg_list=['main', 'overflow'], param_list=[1])
         backward = forward.dagger()
 
-        assert backward.cond_value == 2
+        assert backward.dagger_flag is True
+        assert backward.cond_value == 1
         assert backward.main_reg == 'main'
         assert backward.overflow_reg == 'overflow'
 

--- a/tests/test_intermediate_semantics.py
+++ b/tests/test_intermediate_semantics.py
@@ -1,0 +1,58 @@
+"""Contract tests for pyqres intermediate primitive PySparQ references."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pysparq")
+
+from pyqres.core.metadata import RegisterMetadata
+
+
+@pytest.fixture(autouse=True)
+def fresh_metadata():
+    while len(RegisterMetadata.register_metadata_stack) > 1:
+        RegisterMetadata.pop_register_metadata()
+    RegisterMetadata.register_metadata_stack.clear()
+    RegisterMetadata.push_register_metadata()
+    yield
+    while len(RegisterMetadata.register_metadata_stack) > 0:
+        RegisterMetadata.pop_register_metadata()
+    RegisterMetadata.push_register_metadata()
+
+
+def _declare_reg(name, size, reg_type="UnsignedInteger"):
+    RegisterMetadata.get_register_metadata().declare_register(name, size, reg_type)
+
+
+def test_mod_add_pysparq_reference_fails_closed():
+    """MOD_ADD must not use plain Add_UInt_UInt_InPlace as a false reference."""
+    from pyqres.primitives import MOD_ADD
+
+    _declare_reg("a", 2)
+    _declare_reg("b", 2)
+    op = MOD_ADD(reg_list=["a", "b"], param_list=[3])
+
+    with pytest.raises(NotImplementedError, match="MOD_ADD"):
+        op.pyqsparse_object()
+
+
+def test_mod_mul_pysparq_reference_exists_for_forward_and_dagger():
+    """MOD_MUL uses PySparQ modular multiplication and inverse multiplier for dagger."""
+    from pyqres.primitives import MOD_MUL
+
+    _declare_reg("x", 4)
+    op = MOD_MUL(reg_list=["x"], param_list=[2, 15])
+
+    assert op.pyqsparse_object() is not None
+    assert op.pyqsparse_object(dagger_ctx=True) is not None
+
+
+def test_mod_mul_pysparq_reference_rejects_non_coprime_multiplier():
+    from pyqres.primitives import MOD_MUL
+
+    _declare_reg("x", 4)
+    op = MOD_MUL(reg_list=["x"], param_list=[3, 15])
+
+    with pytest.raises(ValueError, match="coprime"):
+        op.pyqsparse_object()

--- a/tests/test_qda_tridiagonal_statevector.py
+++ b/tests/test_qda_tridiagonal_statevector.py
@@ -1,0 +1,145 @@
+"""Statevector parity for the tridiagonal QDA block-encoding path."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("qiskit", reason="qiskit is required for statevector parity")
+pytest.importorskip("pysparq", reason="pysparq is required for reference simulation")
+
+import pysparq
+from qiskit import QuantumCircuit
+from qiskit.quantum_info import Statevector
+
+from pyqres.algorithms.block_encoding import BlockEncodingTridiagonal
+from pyqres.core.metadata import RegisterMetadata
+from pyqres.core.qec_lowering import QECLoweringVisitor
+
+
+MAX_STATEVECTOR_QUBITS = 25
+
+
+@pytest.fixture(autouse=True)
+def clean_systems():
+    while len(RegisterMetadata.register_metadata_stack):
+        RegisterMetadata.pop_register_metadata()
+    RegisterMetadata.push_register_metadata()
+    pysparq.System.clear()
+    yield
+    while len(RegisterMetadata.register_metadata_stack):
+        RegisterMetadata.pop_register_metadata()
+    RegisterMetadata.push_register_metadata()
+    pysparq.System.clear()
+
+
+def _declare_pyqres_registers():
+    rm = RegisterMetadata.get_register_metadata()
+    rm.declare_register("main", 2, "UnsignedInteger")
+    rm.declare_register("anc_UA", 4, "UnsignedInteger")
+
+
+def _make_qec_circuit():
+    _declare_pyqres_registers()
+    op = BlockEncodingTridiagonal(
+        main_reg="main",
+        anc_UA="anc_UA",
+        alpha=0.5,
+        beta=0.3,
+    )
+    return QECLoweringVisitor().build_circuit(op)
+
+
+def _append_plus_one(qc: QuantumCircuit, qubits, controls=(), inverse=False):
+    qs = list(qubits)
+    cs = list(controls)
+    if inverse:
+        qc.mcx(cs, qs[0]) if cs else qc.x(qs[0])
+        for k in range(1, len(qs)):
+            qc.mcx(cs + qs[:k], qs[k])
+        return
+
+    for k in range(len(qs) - 1, 0, -1):
+        qc.mcx(cs + qs[:k], qs[k])
+    qc.mcx(cs, qs[0]) if cs else qc.x(qs[0])
+
+
+def _append_abstract_gate(qc: QuantumCircuit, gate):
+    name = gate.name
+    qubits = list(gate.qubits)
+    params = list(gate.params)
+
+    if name == "X":
+        qc.x(qubits[0])
+    elif name == "H":
+        qc.h(qubits[0])
+    elif name == "S":
+        qc.s(qubits[0])
+    elif name == "S_DAG":
+        qc.sdg(qubits[0])
+    elif name == "CNOT":
+        qc.cx(qubits[0], qubits[1])
+    elif name == "MCX":
+        qc.x(qubits[0]) if len(qubits) == 1 else qc.mcx(qubits[:-1], qubits[-1])
+    elif name == "RY":
+        qc.ry(float(params[0]), qubits[0])
+    elif name == "RZ":
+        qc.rz(float(params[0]), qubits[0])
+    elif name == "PLUS_ONE":
+        _append_plus_one(qc, qubits)
+    elif name == "PLUS_ONE_DAG":
+        _append_plus_one(qc, qubits, inverse=True)
+    elif name in ("CPLUS_ONE", "CPLUS_ONE_DAG"):
+        n_bits, n_controls = int(params[0]), int(params[1])
+        target = qubits[n_controls:n_controls + n_bits + 1]
+        controls = qubits[:n_controls]
+        _append_plus_one(qc, target, controls, inverse=name.endswith("_DAG"))
+    elif name == "REFLECT":
+        target = qubits[-1]
+        qc.h(target)
+        qc.mcx(qubits[:-1], target) if len(qubits) > 1 else qc.x(target)
+        qc.h(target)
+    else:
+        raise AssertionError(f"Unsupported qiskit parity gate: {gate}")
+
+
+def _qiskit_statevector(circuit):
+    qc = QuantumCircuit(circuit.num_qubits)
+    for gate in circuit.gates:
+        _append_abstract_gate(qc, gate)
+    return np.asarray(Statevector.from_instruction(qc).data)
+
+
+def _pysparq_statevector(num_qubits: int):
+    from pysparq.algorithms.block_encoding import (
+        BlockEncodingTridiagonal as PySparqBlockEncodingTridiagonal,
+    )
+
+    pysparq.System.clear()
+    pysparq.System.add_register("main", pysparq.UnsignedInteger, 2)
+    pysparq.System.add_register("anc_UA", pysparq.UnsignedInteger, 4)
+
+    state = pysparq.SparseState()
+    PySparqBlockEncodingTridiagonal("main", "anc_UA", 0.5, 0.3)(state)
+
+    dense = np.zeros(1 << num_qubits, dtype=complex)
+    main_id = pysparq.System.get_id("main")
+    anc_id = pysparq.System.get_id("anc_UA")
+    for basis_state in state.basis_states:
+        main = basis_state.registers[main_id].value
+        anc = basis_state.registers[anc_id].value
+        dense[main | (anc << 2)] += complex(basis_state.amplitude)
+    return dense
+
+
+def test_block_encoding_tridiagonal_qec_statevector_matches_pysparq():
+    circuit = _make_qec_circuit()
+    assert circuit.num_qubits <= MAX_STATEVECTOR_QUBITS
+    assert circuit.num_qubits == 6
+
+    qiskit_state = _qiskit_statevector(circuit)
+    pysparq_state = _pysparq_statevector(circuit.num_qubits)
+
+    inner = np.vdot(pysparq_state, qiskit_state)
+    phase = inner / abs(inner) if abs(inner) > 1e-12 else 1
+    np.testing.assert_allclose(qiskit_state, phase * pysparq_state, atol=1e-10)

--- a/tests/test_qec_lowering.py
+++ b/tests/test_qec_lowering.py
@@ -100,6 +100,17 @@ class TestBasicGateLowering:
         x_gates = [g for g in circuit.gates if g.name == "X"]
         assert len(x_gates) == 1
 
+    def test_primitive_own_controller_is_applied(self):
+        from pyqres.primitives.gates import X
+
+        _declare_reg("ctrl", 1)
+        _declare_reg("target", 1)
+        op = X(reg_list=["target"], param_list=[0]).control_by_all_ones("ctrl")
+        circuit = _to_circuit(op)
+
+        assert [g.name for g in circuit.gates] == ["MCX"]
+        assert circuit.gates[0].qubits == (0, 1)
+
     def test_reflection_lowering(self):
         from pyqres.primitives.transform import Reflection_Bool
         _declare_reg("q", 3)
@@ -207,6 +218,53 @@ class TestEndToEndCompilation:
         assert [g.name for g in mod_mul_circuit.gates] == ["MOD_MUL"]
         assert lower_to_logical(mod_mul_circuit).ccz_inject_count > 0
 
+    def test_intermediate_dagger_gate_names(self):
+        """Intermediate arithmetic dagger lowers to inverse QEC gate names."""
+        from pyqres.primitives import ADD, MOD_ADD, MOD_MUL, PLUS_ONE
+
+        _declare_reg("a", 2, "UnsignedInteger")
+        _declare_reg("b", 2, "UnsignedInteger")
+        _declare_reg("x", 4, "UnsignedInteger")
+
+        add_circuit = _to_circuit(ADD(reg_list=["a", "b"], param_list=[2]).dagger())
+        assert [g.name for g in add_circuit.gates] == ["ADD_DAG"]
+
+        inc_circuit = _to_circuit(PLUS_ONE(reg_list=["a"], param_list=[2]).dagger())
+        assert [g.name for g in inc_circuit.gates] == ["PLUS_ONE_DAG"]
+
+        mod_add_circuit = _to_circuit(MOD_ADD(reg_list=["a", "b"], param_list=[3]).dagger())
+        assert [g.name for g in mod_add_circuit.gates] == ["MOD_SUB"]
+
+        mod_mul_circuit = _to_circuit(MOD_MUL(reg_list=["x"], param_list=[2, 15]).dagger())
+        assert [g.name for g in mod_mul_circuit.gates] == ["MOD_MUL"]
+        assert mod_mul_circuit.gates[0].params == (8.0, 15.0)
+
+    def test_controlled_mod_mul_lowers_to_controlled_intermediate(self):
+        """Controlled MOD_MUL remains explicit for QEC arithmetic lowering."""
+        from pyqres.primitives import MOD_MUL
+        from qec_compiler.decomposition import lower_to_logical
+
+        _declare_reg("ctrl", 1, "Boolean")
+        _declare_reg("x", 4, "UnsignedInteger")
+        op = MOD_MUL(reg_list=["x"], param_list=[2, 15]).control_by_all_ones("ctrl")
+        circuit = _to_circuit(op)
+
+        assert [g.name for g in circuit.gates] == ["CMOD_MUL"]
+        assert circuit.gates[0].params == (2.0, 15.0, 1.0)
+        assert lower_to_logical(circuit).ccz_inject_count > 0
+
+    def test_control_by_value_zero_bit_uses_x_sandwich(self):
+        """Value controls on zero bits are preserved with X sandwiches."""
+        from pyqres.primitives import MOD_MUL
+
+        _declare_reg("ctrl", 1, "Boolean")
+        _declare_reg("x", 4, "UnsignedInteger")
+        op = MOD_MUL(reg_list=["x"], param_list=[2, 15]).control_by_value({"ctrl": 0})
+        circuit = _to_circuit(op)
+
+        assert [g.name for g in circuit.gates] == ["X", "CMOD_MUL", "X"]
+        assert circuit.gates[0].qubits == circuit.gates[2].qubits == (0,)
+
     def test_mcx_4_controls_compiles(self):
         """MCX with 4 controls compiles with ancilla."""
         from qec_compiler.decomposition import lower_to_logical
@@ -229,7 +287,7 @@ class TestBlockEncodingLowering:
         """BlockEncodingTridiagonal lowers to recognized gate types."""
         from pyqres.algorithms.block_encoding import BlockEncodingTridiagonal
         _declare_reg("main", 2, "UnsignedInteger")
-        _declare_reg("anc_UA", 2)
+        _declare_reg("anc_UA", 4)
 
         op = BlockEncodingTridiagonal(
             main_reg="main", anc_UA="anc_UA", alpha=0.5, beta=0.3)
@@ -243,7 +301,8 @@ class TestBlockEncodingLowering:
         recognized = {
             "H", "X", "Y", "Z", "S", "S_DAG", "T", "T_DAG",
             "CNOT", "CCX", "MCX", "SWAP", "RZ", "RY", "RX",
-            "PHASE", "CPHASE", "REFLECT", "PLUS_ONE",
+            "PHASE", "CPHASE", "REFLECT", "PLUS_ONE", "CPLUS_ONE",
+            "PLUS_ONE_DAG", "CPLUS_ONE_DAG",
         }
         unknown = gate_names - recognized
         assert not unknown, f"Unknown gate names: {unknown}"
@@ -306,7 +365,7 @@ class TestWalkSLowering:
         from pyqres.algorithms.block_encoding import BlockEncodingTridiagonal
         from qec_compiler.decomposition import lower_to_logical
         _declare_reg("main", 2, "UnsignedInteger")
-        _declare_reg("anc_UA", 2)
+        _declare_reg("anc_UA", 4)
         _declare_reg("anc_1", 1)
         _declare_reg("anc_2", 1)
         _declare_reg("anc_3", 1)

--- a/tests/test_qec_lowering.py
+++ b/tests/test_qec_lowering.py
@@ -1,0 +1,320 @@
+"""Integration tests for pyqres → QEC-compiler pipeline.
+
+Tests the full flow:
+  pyqres Operation → QECLoweringVisitor → AbstractCircuit → QECCompiler → LogicalCircuit
+"""
+
+from __future__ import annotations
+
+import pytest
+from pyqres.core.metadata import RegisterMetadata, program_metadata
+
+
+@pytest.fixture(autouse=True)
+def fresh_metadata():
+    """Reset register metadata for each test."""
+    from pyqres.core.metadata import RegisterMetadata
+    while len(RegisterMetadata.register_metadata_stack) > 1:
+        RegisterMetadata.pop_register_metadata()
+    RegisterMetadata.register_metadata_stack.clear()
+    RegisterMetadata.push_register_metadata()
+    yield
+    while len(RegisterMetadata.register_metadata_stack) > 0:
+        RegisterMetadata.pop_register_metadata()
+    RegisterMetadata.push_register_metadata()
+
+
+def _declare_reg(name, size, reg_type="General"):
+    from pyqres.core.metadata import RegisterMetadata
+    RegisterMetadata.get_register_metadata().declare_register(name, size, reg_type)
+
+
+def _make_visitor():
+    from pyqres.core.qec_lowering import QECLoweringVisitor
+    return QECLoweringVisitor()
+
+
+def _to_circuit(op):
+    from pyqres.core.qec_lowering import QECLoweringVisitor
+    v = QECLoweringVisitor()
+    return v.build_circuit(op)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for individual lowering rules
+# ---------------------------------------------------------------------------
+
+class TestBasicGateLowering:
+    def test_public_to_abstract_circuit_entrypoint(self):
+        from pyqres.core.lowering import to_abstract_circuit
+        from pyqres.primitives.gates import Hadamard
+
+        _declare_reg("q", 1)
+        circuit = to_abstract_circuit(Hadamard(reg_list=["q"]))
+
+        assert circuit.num_qubits == 1
+        assert [g.name for g in circuit.gates] == ["H"]
+
+    def test_intermediate_primitives_exported(self):
+        from pyqres.primitives import MCX
+
+        _declare_reg("c", 1)
+        _declare_reg("t", 1)
+        circuit = _to_circuit(MCX(reg_list=["c", "t"]))
+
+        assert [g.name for g in circuit.gates] == ["MCX"]
+
+    def test_unsupported_core_primitive_fails_closed(self):
+        from pyqres.core.qec_lowering import UnsupportedQECPrimitive
+        from pyqres.primitives.arithmetic import CustomArithmetic
+
+        _declare_reg("x", 1)
+        op = CustomArithmetic(
+            reg_list=["x"],
+            param_list=[lambda value: value, 1, 1],
+        )
+
+        with pytest.raises(UnsupportedQECPrimitive, match="CustomArithmetic"):
+            _to_circuit(op)
+
+    def test_hadamard_lowering(self):
+        from pyqres.primitives.gates import Hadamard
+        _declare_reg("q", 2)
+        op = Hadamard(reg_list=["q"])
+        circuit = _to_circuit(op)
+        assert circuit.num_qubits == 2
+        h_gates = [g for g in circuit.gates if g.name == "H"]
+        assert len(h_gates) == 2  # Hadamard on full register
+
+    def test_x_gate_lowering(self):
+        from pyqres.primitives.gates import X
+        _declare_reg("q", 3)
+        op = X(reg_list=["q"], param_list=[1])
+        circuit = _to_circuit(op)
+        x_gates = [g for g in circuit.gates if g.name == "X"]
+        assert len(x_gates) == 1
+
+    def test_reflection_lowering(self):
+        from pyqres.primitives.transform import Reflection_Bool
+        _declare_reg("q", 3)
+        op = Reflection_Bool(reg_list=["q"], param_list=[True])
+        circuit = _to_circuit(op)
+        reflect_gates = [g for g in circuit.gates if g.name == "REFLECT"]
+        assert len(reflect_gates) == 1
+        assert len(reflect_gates[0].qubits) == 3
+
+    def test_plus_one_lowering(self):
+        from pyqres.algorithms.block_encoding import PlusOneOverflow
+        _declare_reg("main", 3, "UnsignedInteger")
+        _declare_reg("overflow", 1, "Boolean")
+        op = PlusOneOverflow(reg_list=["main", "overflow"], param_list=[1])
+        circuit = _to_circuit(op)
+        gate_names = {g.name for g in circuit.gates}
+        assert "PLUS_ONE" in gate_names or "MCX" in gate_names or "X" in gate_names
+
+    def test_qft_lowering(self):
+        from pyqres.primitives.transform import QFT
+        _declare_reg("q", 3)
+        op = QFT(reg_list=["q"])
+        circuit = _to_circuit(op)
+        gate_names = {g.name for g in circuit.gates}
+        assert "H" in gate_names
+        assert "CPHASE" in gate_names
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: pyqres → QEC-compiler
+# ---------------------------------------------------------------------------
+
+class TestEndToEndCompilation:
+    def test_simple_circuit_compiles(self):
+        """H + CNOT circuit compiles through QEC-compiler."""
+        from pyqres.primitives.gates import Hadamard, CNOT
+        from qec_compiler.decomposition import lower_to_logical
+        _declare_reg("q0", 1)
+        _declare_reg("q1", 1)
+
+        # Build a simple circuit using manual gate emission
+        v = _make_visitor()
+        v.alloc.allocate("q0", 1)
+        v.alloc.allocate("q1", 1)
+
+        v._emit_gate("H", (0,))
+        v._emit_gate("CNOT", (0, 1))
+
+        circuit = v.build_circuit()
+        assert circuit.num_qubits == 2
+        assert len(circuit.gates) == 2
+
+        logical = lower_to_logical(circuit)
+        assert logical.ccz_inject_count is not None
+
+    def test_reflect_compiles(self):
+        """REFLECT gate compiles to LogicalCircuit with CCZ gates."""
+        from qec_compiler.decomposition import lower_to_logical
+        from qec_compiler.ir import AbstractCircuit, AbstractGate
+
+        circuit = AbstractCircuit(
+            num_qubits=3,
+            gates=(AbstractGate(name="REFLECT", params=(3,), qubits=(0, 1, 2)),),
+        )
+        logical = lower_to_logical(circuit)
+        assert logical.ccz_inject_count > 0
+
+    def test_plus_one_compiles(self):
+        """PLUS_ONE gate compiles to LogicalCircuit."""
+        from qec_compiler.decomposition import lower_to_logical
+        from qec_compiler.ir import AbstractCircuit, AbstractGate
+
+        circuit = AbstractCircuit(
+            num_qubits=4,
+            gates=(AbstractGate(name="PLUS_ONE", params=(4,), qubits=(0, 1, 2, 3)),),
+        )
+        logical = lower_to_logical(circuit)
+        assert logical.ccz_inject_count > 0
+
+    def test_add_compiles(self):
+        """ADD gate compiles to LogicalCircuit."""
+        from qec_compiler.decomposition import lower_to_logical
+        from qec_compiler.ir import AbstractCircuit, AbstractGate
+
+        circuit = AbstractCircuit(
+            num_qubits=4,
+            gates=(AbstractGate(name="ADD", params=(2,), qubits=(0, 1, 2, 3)),),
+        )
+        logical = lower_to_logical(circuit)
+        assert logical.ccz_inject_count > 0
+
+    def test_pyqres_modular_intermediate_primitives_compile(self):
+        """pyqres MOD_ADD/MOD_MUL primitives lower and compile through QEC."""
+        from pyqres.primitives import MOD_ADD, MOD_MUL
+        from qec_compiler.decomposition import lower_to_logical
+
+        _declare_reg("a", 2, "UnsignedInteger")
+        _declare_reg("b", 2, "UnsignedInteger")
+        mod_add_circuit = _to_circuit(MOD_ADD(reg_list=["a", "b"], param_list=[3]))
+        assert [g.name for g in mod_add_circuit.gates] == ["MOD_ADD"]
+        assert lower_to_logical(mod_add_circuit).ccz_inject_count > 0
+
+        _declare_reg("x", 4, "UnsignedInteger")
+        mod_mul_circuit = _to_circuit(MOD_MUL(reg_list=["x"], param_list=[2, 15]))
+        assert [g.name for g in mod_mul_circuit.gates] == ["MOD_MUL"]
+        assert lower_to_logical(mod_mul_circuit).ccz_inject_count > 0
+
+    def test_mcx_4_controls_compiles(self):
+        """MCX with 4 controls compiles with ancilla."""
+        from qec_compiler.decomposition import lower_to_logical
+        from qec_compiler.ir import AbstractCircuit, AbstractGate
+
+        circuit = AbstractCircuit(
+            num_qubits=5,
+            gates=(AbstractGate(name="MCX", qubits=(0, 1, 2, 3, 4)),),
+        )
+        logical = lower_to_logical(circuit)
+        assert logical.ccz_inject_count > 0
+
+
+# ---------------------------------------------------------------------------
+# BlockEncodingTridiagonal lowering test
+# ---------------------------------------------------------------------------
+
+class TestBlockEncodingLowering:
+    def test_block_encoding_tridiagonal_produces_gates(self):
+        """BlockEncodingTridiagonal lowers to recognized gate types."""
+        from pyqres.algorithms.block_encoding import BlockEncodingTridiagonal
+        _declare_reg("main", 2, "UnsignedInteger")
+        _declare_reg("anc_UA", 2)
+
+        op = BlockEncodingTridiagonal(
+            main_reg="main", anc_UA="anc_UA", alpha=0.5, beta=0.3)
+
+        circuit = _to_circuit(op)
+
+        assert circuit.num_qubits > 0
+        assert len(circuit.gates) > 0
+        gate_names = {g.name for g in circuit.gates}
+        # Should only contain recognized gate names
+        recognized = {
+            "H", "X", "Y", "Z", "S", "S_DAG", "T", "T_DAG",
+            "CNOT", "CCX", "MCX", "SWAP", "RZ", "RY", "RX",
+            "PHASE", "CPHASE", "REFLECT", "PLUS_ONE",
+        }
+        unknown = gate_names - recognized
+        assert not unknown, f"Unknown gate names: {unknown}"
+
+
+# ---------------------------------------------------------------------------
+# QDA WalkS lowering test
+# ---------------------------------------------------------------------------
+
+class TestWalkSLowering:
+    def test_walks_primitive_lowers(self):
+        """WalkS_Primitive with Hadamard fallback lowers to recognized gates."""
+        from pyqres.algorithms.qda_solver import WalkS_Primitive
+        _declare_reg("main", 2, "UnsignedInteger")
+        _declare_reg("anc_UA", 2)
+        _declare_reg("anc_1", 1)
+        _declare_reg("anc_2", 1)
+        _declare_reg("anc_3", 1)
+        _declare_reg("anc_4", 1)
+
+        op = WalkS_Primitive(
+            reg_list=["main", "anc_UA", "anc_1", "anc_2", "anc_3", "anc_4"],
+            param_list=[0.5])
+
+        circuit = _to_circuit(op)
+
+        assert circuit.num_qubits > 0
+        assert len(circuit.gates) > 0
+        gate_names = {g.name for g in circuit.gates}
+        recognized = {
+            "H", "X", "Y", "Z", "S", "S_DAG", "T", "T_DAG",
+            "CNOT", "CCX", "MCX", "SWAP", "RZ", "RY", "RX",
+            "PHASE", "CPHASE", "REFLECT",
+        }
+        unknown = gate_names - recognized
+        assert not unknown, f"Unknown gate names: {unknown}"
+
+    def test_walks_primitive_compiles(self):
+        """WalkS_Primitive compiles through the full QEC pipeline."""
+        from pyqres.algorithms.qda_solver import WalkS_Primitive
+        from qec_compiler.decomposition import lower_to_logical
+        _declare_reg("main", 2, "UnsignedInteger")
+        _declare_reg("anc_UA", 2)
+        _declare_reg("anc_1", 1)
+        _declare_reg("anc_2", 1)
+        _declare_reg("anc_3", 1)
+        _declare_reg("anc_4", 1)
+
+        op = WalkS_Primitive(
+            reg_list=["main", "anc_UA", "anc_1", "anc_2", "anc_3", "anc_4"],
+            param_list=[0.5])
+
+        circuit = _to_circuit(op)
+        logical = lower_to_logical(circuit)
+        assert logical.ccz_inject_count > 0
+
+    def test_walks_with_tridiagonal_compiles(self):
+        """WalkS_Primitive with BlockEncodingTridiagonal compiles through pipeline."""
+        from pyqres.algorithms.qda_solver import WalkS_Primitive
+        from pyqres.algorithms.block_encoding import BlockEncodingTridiagonal
+        from qec_compiler.decomposition import lower_to_logical
+        _declare_reg("main", 2, "UnsignedInteger")
+        _declare_reg("anc_UA", 2)
+        _declare_reg("anc_1", 1)
+        _declare_reg("anc_2", 1)
+        _declare_reg("anc_3", 1)
+        _declare_reg("anc_4", 1)
+
+        def make_enc_A(reg_list=None, param_list=None):
+            return BlockEncodingTridiagonal(
+                main_reg="main", anc_UA="anc_UA", alpha=0.5, beta=0.3)
+
+        op = WalkS_Primitive(
+            reg_list=["main", "anc_UA", "anc_1", "anc_2", "anc_3", "anc_4"],
+            param_list=[0.5],
+            submodules=[make_enc_A])
+
+        circuit = _to_circuit(op)
+        logical = lower_to_logical(circuit)
+        assert logical.ccz_inject_count > 0

--- a/tests/test_qec_lowering.py
+++ b/tests/test_qec_lowering.py
@@ -7,6 +7,12 @@ Tests the full flow:
 from __future__ import annotations
 
 import pytest
+
+pytest.importorskip(
+    "qec_compiler",
+    reason="qec_compiler is required for QEC integration tests",
+)
+
 from pyqres.core.metadata import RegisterMetadata, program_metadata
 
 

--- a/tests/test_qec_shor.py
+++ b/tests/test_qec_shor.py
@@ -11,6 +11,11 @@ from __future__ import annotations
 
 import pytest
 
+pytest.importorskip(
+    "qec_compiler",
+    reason="qec_compiler is required for QEC integration tests",
+)
+
 from pyqres.core.metadata import RegisterMetadata
 
 

--- a/tests/test_qec_shor.py
+++ b/tests/test_qec_shor.py
@@ -1,0 +1,200 @@
+"""Integration tests for Shor N=15 through the pyqres -> QEC-compiler pipeline.
+
+Tests two compilation paths:
+  1. QEC-compiler's built-in Shor fixture -> lower_to_logical -> LogicalCircuit
+  2. pyqres Shor(N=15) -> QECLoweringVisitor -> AbstractCircuit -> lower_to_logical
+
+Also tests MOD_MUL and MOD_ADD intermediate primitives through the pipeline.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyqres.core.metadata import RegisterMetadata
+
+
+@pytest.fixture(autouse=True)
+def fresh_metadata():
+    """Reset register metadata for each test."""
+    from pyqres.core.metadata import RegisterMetadata
+    while len(RegisterMetadata.register_metadata_stack) > 1:
+        RegisterMetadata.pop_register_metadata()
+    RegisterMetadata.register_metadata_stack.clear()
+    RegisterMetadata.push_register_metadata()
+    yield
+    while len(RegisterMetadata.register_metadata_stack) > 0:
+        RegisterMetadata.pop_register_metadata()
+    RegisterMetadata.push_register_metadata()
+
+
+def _declare_reg(name, size, reg_type="General"):
+    RegisterMetadata.get_register_metadata().declare_register(name, size, reg_type)
+
+
+# ---------------------------------------------------------------------------
+# QEC-compiler Shor fixture compilation
+# ---------------------------------------------------------------------------
+
+class TestShorFixtureCompilation:
+    """Test QEC-compiler's built-in Shor fixture compiles through the pipeline."""
+
+    def test_shor_n15_compiles(self):
+        from qec_compiler.cases.benchmark_shor import build_stage5_small_shor_fixture
+        from qec_compiler.decomposition import lower_to_logical
+
+        circuit = build_stage5_small_shor_fixture(modulus=15, base=2)
+        logical = lower_to_logical(circuit)
+
+        assert logical.ccz_inject_count > 0
+
+    def test_shor_n21_compiles(self):
+        from qec_compiler.cases.benchmark_shor import build_stage5_small_shor_fixture
+        from qec_compiler.decomposition import lower_to_logical
+
+        circuit = build_stage5_small_shor_fixture(modulus=21, base=2)
+        logical = lower_to_logical(circuit)
+
+        assert logical.ccz_inject_count > 0
+
+    def test_shor_n15_gate_structure(self):
+        from qec_compiler.cases.benchmark_shor import build_stage5_small_shor_fixture
+
+        circuit = build_stage5_small_shor_fixture(modulus=15, base=2)
+        gate_names = {g.name for g in circuit.gates}
+
+        assert "H" in gate_names
+        assert "CMUL_MOD_N" in gate_names
+        assert "X" in gate_names  # init work register to |1>
+
+    def test_shor_n15_pipeline_decomposes_cmul(self):
+        from qec_compiler.cases.benchmark_shor import build_stage5_small_shor_fixture
+        from qec_compiler.decomposition.cmul_to_mcx_pass import lower_cmul_mod_n
+        from qec_compiler.decomposition.mcx_to_ccx_pass import lower_mcx
+
+        circuit = build_stage5_small_shor_fixture(modulus=15, base=2)
+
+        # Pass 1: CMUL_MOD_N -> MCX
+        after_cmul = lower_cmul_mod_n(circuit)
+        gate_names = {g.name for g in after_cmul.gates}
+        assert "CMUL_MOD_N" not in gate_names
+        assert "MCX" in gate_names
+
+        # Pass 2: MCX -> CCX
+        after_mcx = lower_mcx(after_cmul)
+        gate_names = {g.name for g in after_mcx.gates}
+        assert "MCX" not in gate_names
+
+
+# ---------------------------------------------------------------------------
+# Intermediate primitive compilation (MOD_MUL, MOD_ADD)
+# ---------------------------------------------------------------------------
+
+class TestModularArithmeticCompilation:
+
+    def test_mod_mul_compiles(self):
+        from qec_compiler.ir import AbstractCircuit, AbstractGate
+        from qec_compiler.decomposition import lower_to_logical
+
+        circuit = AbstractCircuit(
+            num_qubits=9,
+            gates=(AbstractGate(name="MOD_MUL", qubits=tuple(range(9)), params=(2, 15)),),
+        )
+        logical = lower_to_logical(circuit)
+        assert logical.ccz_inject_count > 0
+
+    def test_mod_add_compiles(self):
+        from qec_compiler.ir import AbstractCircuit, AbstractGate
+        from qec_compiler.decomposition import lower_to_logical
+
+        circuit = AbstractCircuit(
+            num_qubits=5,
+            gates=(AbstractGate(name="MOD_ADD", qubits=(0, 1, 2, 3, 4), params=(3,)),),
+        )
+        logical = lower_to_logical(circuit)
+        assert logical.ccz_inject_count > 0
+
+
+# ---------------------------------------------------------------------------
+# pyqres Shor lowering -> QEC compilation
+# ---------------------------------------------------------------------------
+
+class TestPyqresShorLowering:
+
+    def test_expmod_lowers_to_cmul(self):
+        """ExpMod lowers to X(init) + CMUL_MOD_N gates."""
+        from pyqres.algorithms.shor import ExpMod
+        from pyqres.core.qec_lowering import QECLoweringVisitor
+
+        _declare_reg("work", 8, "UnsignedInteger")
+        _declare_reg("anc", 4, "UnsignedInteger")
+
+        expmod = ExpMod(
+            reg_list=["work", "anc"],
+            param_list=[2, 15, 4])
+
+        v = QECLoweringVisitor()
+        circuit = v.build_circuit(expmod)
+
+        gate_names = [g.name for g in circuit.gates]
+        assert "X" in gate_names  # init anc to |1>
+        assert "CMUL_MOD_N" in gate_names
+        cmul_count = gate_names.count("CMUL_MOD_N")
+        assert cmul_count == 8  # one per counting bit (2n = 8)
+
+    def test_expmod_cmul_multipliers(self):
+        """CMUL_MOD_N gates have correct multiplier sequence."""
+        from pyqres.algorithms.shor import ExpMod
+        from pyqres.core.qec_lowering import QECLoweringVisitor
+
+        _declare_reg("work", 8, "UnsignedInteger")
+        _declare_reg("anc", 4, "UnsignedInteger")
+
+        expmod = ExpMod(
+            reg_list=["work", "anc"],
+            param_list=[2, 15, 4])
+
+        v = QECLoweringVisitor()
+        circuit = v.build_circuit(expmod)
+
+        cmul_gates = [g for g in circuit.gates if g.name == "CMUL_MOD_N"]
+        multipliers = [g.params[0] for g in cmul_gates]
+        # a=2, N=15: multipliers should be 2, 4, 8, 1, 2, 4, 8, 1
+        expected = [pow(2, 2**k, 15) for k in range(8)]
+        assert multipliers == expected
+
+    def test_shor_full_quantum_lowers(self):
+        """Full quantum Shor(N=15) lowers to AbstractCircuit."""
+        from pyqres.algorithms.shor import Shor
+        from pyqres.core.qec_lowering import QECLoweringVisitor
+
+        _declare_reg("work", 8, "UnsignedInteger")
+        _declare_reg("anc", 4, "UnsignedInteger")
+
+        shor = Shor(reg_list=["work", "anc"], param_list=[2, 15, 4])
+
+        v = QECLoweringVisitor()
+        circuit = v.build_circuit(shor)
+
+        assert circuit.num_qubits == 12  # 8 + 4
+        assert len(circuit.gates) > 0
+        gate_names = {g.name for g in circuit.gates}
+        assert "H" in gate_names
+        assert "CMUL_MOD_N" in gate_names
+
+    def test_shor_compiles_through_pipeline(self):
+        """Full quantum Shor(N=15) compiles through QEC pipeline."""
+        from pyqres.algorithms.shor import Shor
+        from pyqres.core.qec_lowering import QECLoweringVisitor
+        from qec_compiler.decomposition import lower_to_logical
+
+        _declare_reg("work", 8, "UnsignedInteger")
+        _declare_reg("anc", 4, "UnsignedInteger")
+
+        shor = Shor(reg_list=["work", "anc"], param_list=[2, 15, 4])
+
+        v = QECLoweringVisitor()
+        circuit = v.build_circuit(shor)
+        logical = lower_to_logical(circuit)
+
+        assert logical.ccz_inject_count > 0

--- a/tests/test_visualization_html.py
+++ b/tests/test_visualization_html.py
@@ -1,0 +1,152 @@
+"""Tests for interactive HTML visualizations."""
+
+from __future__ import annotations
+
+import pytest
+
+from pyqres.core.metadata import RegisterMetadata
+from pyqres.core.operation import StandardComposite
+from pyqres.algorithms.block_encoding import BlockEncodingTridiagonal
+from pyqres.generated import QDALinearSolver
+from pyqres.primitives import CNOT, Hadamard, X
+from pyqres.visualization import (
+    operation_to_tree_data,
+    render_call_tree_html,
+    render_circuit_html,
+    write_call_tree_html,
+    write_circuit_html,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_metadata():
+    while len(RegisterMetadata.register_metadata_stack):
+        RegisterMetadata.pop_register_metadata()
+    RegisterMetadata.push_register_metadata()
+    yield
+    while len(RegisterMetadata.register_metadata_stack):
+        RegisterMetadata.pop_register_metadata()
+    RegisterMetadata.push_register_metadata()
+
+
+class BellPair(StandardComposite):
+    def __init__(self):
+        super().__init__(reg_list=["ctrl", "target"])
+        self.program_list = [
+            Hadamard(["ctrl"]),
+            CNOT(["ctrl", "target"], [0, 0]),
+            X(["target"], [0]).control_by_all_ones("ctrl"),
+        ]
+        self.declare_program_list()
+
+
+def _declare_regs():
+    rm = RegisterMetadata.get_register_metadata()
+    rm.declare_register("ctrl", 1)
+    rm.declare_register("target", 1)
+
+
+def _declare_qda_regs():
+    rm = RegisterMetadata.get_register_metadata()
+    rm.declare_register("main_reg", 2, "UnsignedInteger")
+    rm.declare_register("anc_UA", 4, "UnsignedInteger")
+    rm.declare_register("anc_1", 1, "Boolean")
+    rm.declare_register("anc_2", 1, "Boolean")
+    rm.declare_register("anc_3", 1, "Boolean")
+    rm.declare_register("anc_4", 1, "Boolean")
+
+
+def _make_tridiagonal_qda():
+    def encode_a(reg_list=None, param_list=None):
+        return BlockEncodingTridiagonal(
+            main_reg=reg_list[0],
+            anc_UA=reg_list[1],
+            alpha=0.5,
+            beta=0.3,
+        )
+
+    return QDALinearSolver(
+        reg_list=["main_reg", "anc_UA", "anc_1", "anc_2", "anc_3", "anc_4"],
+        param_list=[2.0, 0.5],
+        operations=[encode_a, Hadamard],
+    )
+
+
+def test_operation_to_tree_data_contains_children_and_controls():
+    _declare_regs()
+    data = operation_to_tree_data(BellPair())
+
+    assert data["root"]["name"] == "BellPair"
+    assert [child["name"] for child in data["root"]["children"]] == [
+        "Hadamard",
+        "CNOT",
+        "X",
+    ]
+    assert data["root"]["children"][2]["controllerRegisters"] == ["ctrl"]
+
+
+def test_render_call_tree_html_is_standalone_and_expandable():
+    _declare_regs()
+    html = render_call_tree_html(BellPair())
+
+    assert "<!doctype html>" in html
+    assert "window.PYQRES_TREE_DATA" in html
+    assert "<details" in html
+    assert "BellPair" in html
+    assert "Hadamard" in html
+
+
+def test_render_circuit_html_has_sidebar_and_circuit_renderer():
+    _declare_regs()
+    html = render_circuit_html(BellPair())
+
+    assert "Register circuit" in html
+    assert "module-toggle" in html
+    assert "circuit-grid" in html
+    assert "flattenCircuit" in html
+    assert "depth < maxDepth" in html
+    assert "depth === 0" not in html
+
+
+def test_write_visualization_files(tmp_path):
+    _declare_regs()
+    op = BellPair()
+
+    call_tree_path = write_call_tree_html(op, tmp_path / "tree.html")
+    circuit_path = write_circuit_html(op, tmp_path / "circuit.html")
+
+    assert call_tree_path.exists()
+    assert circuit_path.exists()
+    assert "BellPair" in call_tree_path.read_text()
+    assert "BellPair" in circuit_path.read_text()
+
+
+def test_qda_visualization_has_expandable_nested_modules_and_split_sizes():
+    _declare_qda_regs()
+    data = operation_to_tree_data(_make_tridiagonal_qda())
+
+    modules = []
+
+    def collect(node):
+        if node["kind"] == "composite":
+            modules.append((node["path"], node["name"]))
+        for child in node["children"]:
+            collect(child)
+
+    collect(data["root"])
+
+    assert ("0", "QDALinearSolver") in modules
+    assert any(name == "WalkS_Primitive" for _path, name in modules)
+    assert any(name == "BlockEncodingTridiagonal" for _path, name in modules)
+    assert {"name": "_overflow", "size": "1", "type": "General"} in data["registers"]
+    assert {"name": "_other", "size": "1", "type": "General"} in data["registers"]
+
+
+def test_qda_circuit_html_lists_root_and_nested_module_toggles():
+    _declare_qda_regs()
+    html = render_circuit_html(_make_tridiagonal_qda())
+
+    assert '"name": "QDALinearSolver"' in html
+    assert "WalkS_Primitive" in html
+    assert "BlockEncodingTridiagonal" in html
+    assert "${escapeHtml(node.name)} (root)" in html


### PR DESCRIPTION
## Summary
- add the frozen QEC intermediate primitive contract documentation
- complete controlled and dagger lowering paths for arithmetic/intermediate primitives
- add PySparQ/Qiskit statevector parity for the tridiagonal QDA block encoding
- add standalone HTML visualizations for call trees and register-level circuits

## Validation
- Quantum-Resource-Estimator: `.venv/bin/pytest -q` -> 344 passed, 2 skipped
