### PR TITLE
[codex] refactor quantikz rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,17 @@ For a QDA-Tridiagonal example:
 python examples/qda_tridiagonal_visualization.py
 ```
 
+For LaTeX output, `pyqres.quantikz.QuantikzVisitor` compiles an `Operation`
+tree into register-level Quantikz:
+
+```python
+from pyqres.quantikz import QuantikzVisitor
+
+visitor = QuantikzVisitor()
+op.traverse(visitor)
+latex = visitor.to_latex()
+```
+
 See `docs/source/visualization/index.rst` for details.
 
 ## Tests And Docs

--- a/docs/source/api/quantikz.rst
+++ b/docs/source/api/quantikz.rst
@@ -1,16 +1,15 @@
 pyqres.quantikz
 ===============
 
-.. warning::
-
-   ``pyqres.quantikz`` 模块当前正在重构中，暂时不可用。
-
-   该模块将适配新的 Operation 类层次结构后重新启用。
-
 模块概述
 --------
 
-quantikz 模块提供 Quantikz LaTeX 量子线路图生成功能，包含以下核心类：
+``pyqres.quantikz`` 模块提供 Quantikz LaTeX 量子线路图生成功能。当前实现以
+pyqres 的 ``Operation`` 树为主入口：visitor 会展开 composite，继承父级
+controller，处理 dagger 上下文，并将 primitive/register operation 编译为
+register-level Quantikz timeline。
+
+核心类包括：
 
 - :class:`~pyqres.quantikz.generator.QuantumCircuit` - 量子电路表示
 - :class:`~pyqres.quantikz.generator.QReg` - 量子寄存器
@@ -18,11 +17,36 @@ quantikz 模块提供 Quantikz LaTeX 量子线路图生成功能，包含以下�
 - :class:`~pyqres.quantikz.generator.Controller` - 控制器数据类
 - :class:`~pyqres.quantikz.generator.LatexGenerator` - LaTeX 代码生成器
 - :class:`~pyqres.quantikz.generator.Compiler` - LaTeX 编译器
+- :class:`~pyqres.quantikz.visitor.QuantikzVisitor` - Operation 树编译 visitor
 
-使用示例（重构完成后）
-----------------------
+从 Operation 树生成线路图
+--------------------------
 
 从操作树生成 LaTeX 线路图：
+
+.. code-block:: python
+
+   from pyqres.core.metadata import RegisterMetadata
+   from pyqres.primitives import Hadamard, X
+   from pyqres.quantikz import QuantikzVisitor
+
+   rm = RegisterMetadata.get_register_metadata()
+   rm.declare_register("ctrl", 1)
+   rm.declare_register("q", 1)
+
+   op = X(["q"], [0]).control_by_bit([("ctrl", 0)])
+
+   visitor = QuantikzVisitor()
+   op.traverse(visitor)
+   latex_code = visitor.to_latex()
+
+``to_latex()`` 返回完整 standalone LaTeX 文档；``to_latex_figure(caption)``
+返回可嵌入已有 LaTeX 文档的 ``figure`` 环境。
+
+直接构造线路
+------------
+
+如果不从 ``Operation`` 树出发，也可以直接构造 register-level timeline：
 
 .. code-block:: python
 
@@ -30,10 +54,8 @@ quantikz 模块提供 Quantikz LaTeX 量子线路图生成功能，包含以下�
        QuantumCircuit, OpCode, Controller, LatexGenerator, Compiler
    )
 
-   # 创建电路
    circuit = QuantumCircuit({'q1': 1, 'q2': 1, 'ctrl': 1})
 
-   # 添加操作
    circuit.add_op(OpCode(
        name='CNOT',
        targets=['q1'],
@@ -41,11 +63,18 @@ quantikz 模块提供 Quantikz LaTeX 量子线路图生成功能，包含以下�
    ))
    circuit.add_op(OpCode(name='H', targets=['q2']))
 
-   # 生成 LaTeX
    latex_code = LatexGenerator.generate(circuit)
-
-   # 编译为 PDF
    Compiler.compile(latex_code, 'my_circuit.tex')
+
+语义说明
+--------
+
+- 输出是 register-level 线路图，不展开到单个物理 qubit wire。
+- composite 会按当前 pyqres traversal 规则展开；dagger composite 会逆序遍历子操作。
+- controller context 会传播到子 primitive，并渲染为 Quantikz control。
+- ``SplitRegister``、``CombineRegister``、``AddRegister``、``RemoveRegister``
+  等 register operation 会作为显式 register-level gate 显示。
+- LaTeX 特殊字符会被转义，例如 ``_overflow`` 会渲染为 ``\_overflow``。
 
 依赖要求
 --------

--- a/docs/source/visualization/index.rst
+++ b/docs/source/visualization/index.rst
@@ -117,14 +117,24 @@ Quantum-Resource-Estimator 支持使用 Quantikz LaTeX 包生成量子线路图�
 
 .. code-block:: python
 
-   from pyqres.quantikz import QuantumCircuit
+   from pyqres.core.metadata import RegisterMetadata
+   from pyqres.primitives import X
+   from pyqres.quantikz import QuantikzVisitor
 
-   # 创建线路图
-   circuit = QuantumCircuit()
-   # ... 添加操作
+   rm = RegisterMetadata.get_register_metadata()
+   rm.declare_register("ctrl", 1)
+   rm.declare_register("q", 1)
 
-   # 生成 LaTeX
-   latex = circuit.to_latex()
+   op = X(["q"], [0]).control_by_all_ones("ctrl")
+
+   visitor = QuantikzVisitor()
+   op.traverse(visitor)
+   latex = visitor.to_latex()
+
+Quantikz 输出是 register-level 线路图。它会展开 pyqres ``Operation`` 树，
+继承 controller context，并按照 dagger traversal 逆序渲染子操作。若需要直接
+构造 timeline，也可以使用 ``QuantumCircuit``、``OpCode`` 和
+``LatexGenerator``。
 
 依赖
 ~~~~

--- a/pyqres/core/metadata.py
+++ b/pyqres/core/metadata.py
@@ -1,4 +1,5 @@
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Union
+
 from sympy import Symbol
 
 
@@ -45,7 +46,7 @@ class RegisterMetadata:
         old_size = self.registers[reg]
         for name, size in new_reg_declarations:
             if name not in self.registers:
-                raise ValueError(f"Register {name} not declared")
+                self.declare_register(name, size)
             if isinstance(size, int) and isinstance(old_size, int) and size > old_size:
                 raise ValueError(f"Register {reg} size too small to split")
             self.registers[name] = size
@@ -153,10 +154,6 @@ class FunctionDeclaration:
         self.program_list = program_list or []
 
     def __str__(self):
-        from .registry import OperationRegistry
-        from .utils import reg_sz, merge_controllers
-        import inspect
-
         mock_register_metadata = RegisterMetadata.push_register_metadata()
         regs = [f"q_{i}" for i in range(self.reg_count)]
         size_param = 0

--- a/pyqres/quantikz/__init__.py
+++ b/pyqres/quantikz/__init__.py
@@ -1,7 +1,12 @@
-from .generator import QReg, Controller, OpCode, QuantumCircuit, LatexGenerator, Compiler
+from .generator import Compiler, Controller, LatexGenerator, OpCode, QReg, QuantumCircuit
 from .visitor import QuantikzVisitor
 
 __all__ = [
-    "QReg", "Controller", "OpCode", "QuantumCircuit",
-    "LatexGenerator", "Compiler", "QuantikzVisitor",
+    "Compiler",
+    "Controller",
+    "LatexGenerator",
+    "OpCode",
+    "QReg",
+    "QuantumCircuit",
+    "QuantikzVisitor",
 ]

--- a/pyqres/quantikz/generator.py
+++ b/pyqres/quantikz/generator.py
@@ -1,350 +1,331 @@
-from dataclasses import dataclass, field
+from __future__ import annotations
+
 import os
-from pathlib import Path
 import subprocess
-from typing import List, Dict, Union
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
 from sympy import Symbol, latex
 
+
+@dataclass
 class QReg:
-    def __init__(self, name: str, size: int):
-        self.name = name
-        self.size = size
-    
+    name: str
+    size: Any
+    reg_type: str = "General"
+
     def __hash__(self):
-        return hash(self.name + str(self.size))
-    
-    def __eq__(self, value):
-        return self.name == value.name and self.size == value.size
-    
+        return hash((self.name, str(self.size), self.reg_type))
+
     def __str__(self):
         return f"{self.name}[{self.size}]"
-    
+
     def __repr__(self):
-        return f"{self.name}[{self.size}]"
+        return str(self)
+
 
 @dataclass
 class Controller:
     qreg: str
     control_type: str
-    control_info: any = None
+    control_info: Any = None
+
 
 @dataclass
 class OpCode:
     name: str
-    targets: List[str]
-    params: List[Union[float, Symbol]] = field(default_factory=list)
-    controls: List[Controller] = field(default_factory=list)
-    dagger : bool = False
+    targets: list[str]
+    params: list[Any] = field(default_factory=list)
+    controls: list[Controller] = field(default_factory=list)
+    dagger: bool = False
+
 
 class QuantumCircuit:
-    def __init__(self, registers: Dict[str, int]):
-        self.registers = {name: QReg(name, size) for name, size in registers.items()}
-        self.timeline = []
-    
-    def add_op(self, op: OpCode):
+    """Register-level circuit model consumed by the Quantikz generator.
+
+    The model is intentionally small: rows are named registers, columns are
+    semantic operations.  It keeps the old public class name while avoiding the
+    previous register-permutation based renderer, which was fragile once
+    pyqres grew dynamic registers and nested operation trees.
+    """
+
+    def __init__(self, registers: Mapping[str, Any] | None = None):
+        if registers is None:
+            from pyqres.core.metadata import RegisterMetadata
+
+            registers = RegisterMetadata.get_registers()
+        self.registers: dict[str, QReg] = {}
+        self.timeline: list[OpCode] = []
+        for name, size in registers.items():
+            self.ensure_register(str(name), size)
+
+    def ensure_register(self, name: str, size: Any = "?", reg_type: str = "General") -> None:
+        if name in self.registers:
+            reg = self.registers[name]
+            if size not in (None, "?"):
+                reg.size = size
+            if reg_type != "General":
+                reg.reg_type = reg_type
+            return
+        self.registers[name] = QReg(name, size, reg_type)
+
+    def add_op(self, op: OpCode) -> None:
+        for reg in op.targets:
+            self.ensure_register(str(reg))
+        for control in op.controls:
+            self.ensure_register(str(control.qreg))
         self.timeline.append(op)
 
-    def split_registers(self, reg_list, param_list):
-        reg0 = self.registers[reg_list[0]]
+    def split_registers(self, reg_list, param_list) -> None:
+        if not reg_list:
+            return
+        parent = str(reg_list[0])
+        self.ensure_register(parent)
+        remaining = self.registers[parent].size
+        if isinstance(remaining, int) and all(isinstance(size, int) for size in param_list):
+            remaining -= sum(param_list)
+        for reg, size in zip(reg_list[1:], param_list):
+            self.ensure_register(str(reg), size)
+        self.registers[parent].size = remaining
 
-        for reg_name, new_size in zip(reg_list[1:], param_list):
-            reg = self.registers[reg_name]
-            reg0.size -= new_size
-            reg.size += new_size
-        
+    def merge_registers(self, reg_list, param_list=None) -> None:
+        if not reg_list:
+            return
+        parent = str(reg_list[0])
+        self.ensure_register(parent)
+        total = self.registers[parent].size
+        for reg in reg_list[1:]:
+            name = str(reg)
+            self.ensure_register(name)
+            size = self.registers[name].size
+            if isinstance(total, int) and isinstance(size, int):
+                total += size
+            self.registers[name].size = 0
+        self.registers[parent].size = total
 
-    def merge_registers(self, reg_list, param_list):
-        reg0 = self.registers[reg_list[0]]
 
-        for reg_name, new_size in zip(reg_list[1:], param_list):
-            reg = self.registers[reg_name]
-            reg0.size += reg.size
-            reg.size -= new_size
-            
-        
 class LatexGenerator:
     @staticmethod
     def generate(circuit: QuantumCircuit) -> str:
         gen = LatexGenerator(circuit)
         return gen._build_full_document()
-    
+
     @staticmethod
     def generate_as_figure(circuit: QuantumCircuit, figure_caption: str) -> str:
         gen = LatexGenerator(circuit)
         return gen._build_as_figure(figure_caption)
 
+    @staticmethod
+    def generate_body(circuit: QuantumCircuit) -> str:
+        gen = LatexGenerator(circuit)
+        return gen._build_body()
+
     def __init__(self, circuit: QuantumCircuit):
         self.circuit = circuit
-        self.lines = []
-        self.current_order = []
-        self._init_lines()
-
-    def _init_lines(self):
-        """初始化每行的起始部分"""
-        self.lines = [
-            [f"\\lstick{{${reg.name}$}} & \\qwbundle{{{reg.size}}}"] 
-            for reg in self.circuit.registers.values()
-        ]
-        self.current_order = list(self.circuit.registers.keys())
+        self.register_order = list(circuit.registers.keys())
 
     def _build_full_document(self) -> str:
-        """构建完整LaTeX文档"""
-        layers = self._process_into_layers(self.circuit.timeline)
+        return "\n".join(
+            [
+                r"\documentclass{standalone}",
+                r"\usepackage{tikz}",
+                r"\usetikzlibrary{quantikz2}",
+                r"\begin{document}",
+                self._build_body(),
+                r"\end{document}",
+            ]
+        )
 
-        for ops, qubits in layers:
-            self._process_operation_layer(ops)
-        
-        self._finalize_lines()
-        return self._assemble_document()
-    
-    def _build_as_figure(self, figure_caption) -> str:
-        """构建完整LaTeX文档"""
-        layers = self._process_into_layers(self.circuit.timeline)
+    def _build_as_figure(self, figure_caption: str) -> str:
+        return "\n".join(
+            [
+                r"\begin{figure}",
+                r"\centering",
+                self._build_body(),
+                r"\caption{" + self._latex_text(figure_caption) + r"}",
+                r"\end{figure}",
+            ]
+        )
 
-        for ops, qubits in layers:
-            self._process_operation_layer(ops)
-        
-        self._finalize_lines()
-        return self._assemble_as_figure(figure_caption)
+    def _build_body(self) -> str:
+        lines = self._initial_lines()
+        for layer in self._process_into_layers(self.circuit.timeline):
+            self._append_layer(lines, layer)
+        for row in self.register_order:
+            lines[row].append(r"\qw")
 
-    def _process_into_layers(self, ops: List[OpCode]) -> List[List[OpCode]]:
-        """将操作分层"""
+        body = [" & ".join(lines[row]) + r" \\" for row in self.register_order]
+        return "\n".join(
+            [
+                r"\begin{quantikz}",
+                *body,
+                r"\end{quantikz}",
+            ]
+        )
 
-        # 每一层由操作+已经含有的量子比特构成
-        layers = [(list(),set())]
+    def _initial_lines(self) -> dict[str, list[str]]:
+        lines = {}
+        for reg in self.circuit.registers.values():
+            label = self._latex_register_name(reg.name)
+            lines[reg.name] = [rf"\lstick{{$ {label} $}}", rf"\qwbundle{{{self._format_size(reg.size)}}}"]
+        return lines
+
+    def _append_layer(self, lines: dict[str, list[str]], ops: list[OpCode]) -> None:
+        row_index = {reg: idx for idx, reg in enumerate(self.register_order)}
+        cells = {reg: r"\qw" for reg in self.register_order}
+
         for op in ops:
-            # 找到layers中第一个可以包含op的层
-            for i, (layer, qubits) in enumerate(layers):
-                op_qubits = set(op.targets + LatexGenerator._get_control_regs(op.controls))
+            targets = [str(reg) for reg in op.targets if str(reg) in row_index]
+            controls = [
+                control
+                for control in op.controls
+                if str(control.qreg) in row_index and str(control.qreg) not in targets
+            ]
+            involved = [str(control.qreg) for control in controls] + targets
+            if not involved:
+                continue
 
-                #查看是否有交集，如果没有交集，则可以放入该层
-                if not any(q in qubits for q in op_qubits):
-                    layers[i] = (layer + [op], qubits.union(set(op.targets + LatexGenerator._get_control_regs(op.controls))))
+            anchor = targets[0] if targets else involved[0]
+            anchor_idx = row_index[anchor]
+            gate = self._format_gate(op)
+
+            for control in controls:
+                control_reg = str(control.qreg)
+                delta = anchor_idx - row_index[control_reg]
+                cells[control_reg] = self._format_control(control, delta)
+
+            if targets:
+                for target in targets:
+                    cells[target] = rf"\gate{{{gate}}}"
+            else:
+                cells[anchor] = rf"\gate{{{gate}}}"
+
+        for reg in self.register_order:
+            lines[reg].append(cells[reg])
+
+    @staticmethod
+    def _process_into_layers(ops: list[OpCode]) -> list[list[OpCode]]:
+        layers: list[tuple[list[OpCode], set[str]]] = []
+        for op in ops:
+            op_regs = set(op.targets)
+            op_regs.update(control.qreg for control in op.controls)
+            for layer, used_regs in layers:
+                if not op_regs.intersection(used_regs):
+                    layer.append(op)
+                    used_regs.update(op_regs)
                     break
             else:
-                # 找不到合适的层，新建层
-                layers.append(([op], set(op.targets + LatexGenerator._get_control_regs(op.controls))))
-
-        return layers
-
-    def _process_operation(self, op: OpCode):
-        """处理单个量子操作"""
-        new_order = self._calculate_new_order(op)
-        self._handle_permutation(new_order)        
-        self._sync_targets(op.targets + LatexGenerator._get_control_regs(op.controls))
-        self._add_gate_operation(op)
-        self._add_control_lines(op)
-    
-    @staticmethod
-    def _get_control_regs(controls: List[Controller]) -> List[str]:
-        """获取控制比特"""
-        return [c.qreg for c in controls]
-
-    @staticmethod
-    def extract_layer_involved_qregs(ops: List[OpCode]) -> List[str]:
-        """提取所有操作的量子比特"""
-        qubits = []
-        for op in ops:
-            qubits += op.targets + LatexGenerator._get_control_regs(op.controls)
-
-        return qubits
-
-    def _process_operation_layer(self, ops: List[OpCode]):
-        """处理一层量子操作"""
-        new_order = self._calculate_new_order(LatexGenerator.extract_layer_involved_qregs(ops))
-        self._handle_permutation(new_order)
-        self._sync_targets(LatexGenerator.extract_layer_involved_qregs(ops))
-        for op in ops:
-            self._add_gate_operation(op)
-            self._add_control_lines(op)
-
-    def _calculate_new_order(self, involved: List[str]) -> List[str]:
-        """计算需要的新寄存器顺序"""
-        # involved = op.targets + LatexGenerator._get_control_regs(op.controls)
-        return [r for r in involved if r in self.current_order] + \
-               [r for r in self.current_order if r not in involved]
-
-    def _handle_permutation(self, new_order: List[str]):
-        """处理寄存器置换逻辑"""
-        if new_order == self.current_order:
-            return
-
-        perm_indices = [str(self.current_order.index(r)+1) for r in new_order]        
-        self._add_permute_command(perm_indices)
-        self.current_order = new_order
-        self._update_labels_after_permutation()
-
-    def _add_permute_command(self, perm_indices: List[str]):
-        """添加permute命令到第一行"""
-
-        self._sync_all()
-        cmd = f"\\permute{{{','.join(perm_indices)}}}"
-        self._add_to_line(0, cmd)
-        for i in range(1, len(self.lines)):
-            self._add_to_line(i, " ")
-
-    def _update_labels_after_permutation(self):
-        """置换后更新所有寄存器标签"""
-        for i, reg_name in enumerate(self.current_order):
-            reg_size = self.circuit.registers[reg_name].size
-            self._add_to_line(i, f"\\push{{{reg_name}}} \\qwbundle{{{reg_size}}}")
-
-    def _sync_targets(self, targets : List[str]):
-        """同步目标线路的列数"""
-        max_len = max(len(self.lines[self.current_order.index(target)]) for target in targets)
-        for target in set(targets):
-            line_idx = self.current_order.index(target)
-            line = self.lines[line_idx]
-            while len(line) < max_len:
-                line.append("& \\qw")
-
-    def _sync_all(self):
-        """同步所有线路的列数"""
-        max_len = max(len(line) for line in self.lines)
-        for line in self.lines:
-            while len(line) < max_len:
-                line.append("& \\qw")
-
-    def _add_gate_operation(self, op: OpCode):
-        """添加门操作到线路"""
-        gate_str = self._format_gate(op)
-        target_count = len(op.targets)
-        
-        for i, target in enumerate(op.targets):
-            line_idx = self.current_order.index(target)
-            cmd = f"\\gate[{target_count}]{{{gate_str}}}" if i == 0 else "\\ghost{}"
-            self._add_to_line(line_idx, cmd)
-        
-
-    def _add_control_lines(self, op: OpCode):
-        """添加控制线"""
-        if not op.controls:
-            return
-
-        main_target_idx = self.current_order.index(op.targets[0])
-        existed_controls = set()
-        for control in op.controls:
-            control_idx = self.current_order.index(control.qreg)
-            
-            if control_idx in existed_controls:
-                raise NotImplementedError("Multiple controls on the same qubit are not supported yet.")
-            existed_controls.add(control_idx)
-
-            delta = main_target_idx - control_idx
-
-            control_type = control.control_type
-            if control_type == 'conditioned_by_all_ones':
-                self._add_to_line(control_idx, f"\\ctrl{{{delta}}}")
-            elif control_type == 'conditioned_by_nonzero':
-                self._add_to_line(control_idx, f"\\ctrl[open]{{{delta}}}\\midstick[1,brackets=none]{{$\\neq 0$}}")
-            elif control_type == 'conditioned_by_value':
-                value = control.control_info
-                self._add_to_line(control_idx, f"\\ctrl[open]{{{delta}}}\\midstick[1,brackets=none]{{={value}}}")
-            elif control_type == 'conditioned_by_bit':
-                bit = control.control_info
-                self._add_to_line(control_idx, f"\\ctrl[open]{{{delta}}}\\midstick[1,brackets=none]{{[{bit}]}}")
-            else:
-                raise ValueError(f"Unknown control type: {control_type}")
-            
-    def _restore_original_order(self):
-        """恢复原始寄存器顺序"""
-        if self.current_order == self.circuit.registers:
-            return
-
-        rev_perm = [str(self.current_order.index(r)+1) for r in self.circuit.registers.keys()]
-        self._add_permute_command(rev_perm)
-        self.current_order = list(self.circuit.registers.keys())
-        self._update_labels_after_permutation()
-
-    def _add_to_line(self, line_idx: int, command: str):
-        """向指定行添加命令"""
-        self.lines[line_idx].append(f"& {command}")
-
-    def _finalize_lines(self):
-        """为每行添加结束标记"""
-        self._restore_original_order()
-        for i in range(len(self.lines)):
-            self._add_to_line(i, "\\qw")
-            self.lines[i].append("\\\\")
-
-    def _assemble_document(self) -> str:
-        """组合所有部分生成最终文档"""
-        body = ["\n".join(line) for line in self.lines]
-        return "\n".join([
-            r"\documentclass{standalone}",
-            r"\usepackage{tikz}",
-            r"\usetikzlibrary{quantikz2}",
-            r"\begin{document}",
-            r"\begin{quantikz}",
-            *body,
-            r"\end{quantikz}",
-            r"\end{document}"
-        ])
-
-    def _assemble_as_figure(self, figure_caption) -> str:
-        """组合所有部分生成最终文档"""
-        body = ["\n".join(line) for line in self.lines]
-        return "\n".join([
-            r"\begin{figure}",
-            r"\begin{quantikz}",
-            *body,
-            r"\end{quantikz}",
-            r"\caption{" + figure_caption + r"}",
-            r"\end{figure}"
-        ])
+                layers.append(([op], set(op_regs)))
+        return [layer for layer, _used_regs in layers]
 
     @staticmethod
     def _format_gate(op: OpCode) -> str:
-        """格式化门参数"""
         params = LatexGenerator._format_params(op.params)
-        dagger = "^\\dagger" if op.dagger else ""
-        return f"\\mathrm{{{op.name}}}{dagger}{params}"
+        dagger = r"^{\dagger}" if op.dagger else ""
+        return rf"\mathrm{{{LatexGenerator._latex_text(op.name)}}}{dagger}{params}"
+
+    @staticmethod
+    def _format_control(control: Controller, delta: int) -> str:
+        if control.control_type == "conditioned_by_all_ones":
+            return rf"\ctrl{{{delta}}}"
+        label = LatexGenerator._control_label(control)
+        return rf"\ctrl[open]{{{delta}}}{label}"
+
+    @staticmethod
+    def _control_label(control: Controller) -> str:
+        if control.control_type == "conditioned_by_nonzero":
+            return r"\midstick[1,brackets=none]{$\neq 0$}"
+        if control.control_type == "conditioned_by_value":
+            return rf"\midstick[1,brackets=none]{{$={LatexGenerator._latex_value(control.control_info)}$}}"
+        if control.control_type == "conditioned_by_bit":
+            return rf"\midstick[1,brackets=none]{{$[{LatexGenerator._latex_value(control.control_info)}]$}}"
+        raise ValueError(f"Unknown control type: {control.control_type}")
 
     @staticmethod
     def _format_params(params) -> str:
-        """格式化参数列表"""
         if not params:
             return ""
-        param_strs = []
-        for p in params:
-            if isinstance(p, Symbol):
-                param_strs.append(latex(p))
-            elif isinstance(p, float):
-                param_strs.append(f"{p:.2f}".rstrip('0').rstrip('.'))
-            else:
-                param_strs.append(str(p))
-        return f"({', '.join(param_strs)})"
-    
+        return "(" + ", ".join(LatexGenerator._latex_value(param) for param in params) + ")"
+
+    @staticmethod
+    def _latex_value(value: Any) -> str:
+        if isinstance(value, Symbol):
+            return latex(value)
+        if isinstance(value, float):
+            return f"{value:.6g}"
+        if isinstance(value, (list, tuple)):
+            return "(" + ", ".join(LatexGenerator._latex_value(item) for item in value) + ")"
+        return LatexGenerator._latex_text(str(value))
+
+    @staticmethod
+    def _format_size(size: Any) -> str:
+        if isinstance(size, Symbol):
+            return latex(size)
+        return LatexGenerator._latex_text(str(size))
+
+    @staticmethod
+    def _latex_register_name(name: str) -> str:
+        return LatexGenerator._latex_text(str(name))
+
+    @staticmethod
+    def _latex_text(text: str) -> str:
+        replacements = {
+            "\\": r"\textbackslash{}",
+            "_": r"\_",
+            "&": r"\&",
+            "%": r"\%",
+            "$": r"\$",
+            "#": r"\#",
+            "{": r"\{",
+            "}": r"\}",
+            "~": r"\textasciitilde{}",
+            "^": r"\textasciicircum{}",
+        }
+        return "".join(replacements.get(char, char) for char in text)
+
 
 class Compiler:
     @staticmethod
-    def compile(latex_code: str, filename, tex_path = 'tex_outputs', pdf_path = 'pdf_outputs'):
-        """编译LaTeX代码"""
+    def compile(
+        latex_code: str,
+        filename,
+        tex_path="tex_outputs",
+        pdf_path="pdf_outputs",
+        engine="pdflatex",
+    ) -> Path:
+        """Compile Quantikz LaTeX to PDF and return the generated PDF path."""
 
         os.makedirs(tex_path, exist_ok=True)
         os.makedirs(pdf_path, exist_ok=True)
 
-        tex_path = Path(tex_path)
-        pdf_path = Path(pdf_path)
-        pdf_path_ = str(pdf_path).replace("\\", "/")
-        with open(tex_path / filename, "w") as f:
-            f.write(latex_code)
-        
-        texfile = str(tex_path / f"{filename}")
-        texfile = texfile.replace("\\", "/")
-        # print(f"Compiling {texfile}...")
-        # print("Output directory:", pdf_path_)
+        tex_dir = Path(tex_path)
+        pdf_dir = Path(pdf_path)
+        tex_file = Path(filename)
+        if tex_file.suffix != ".tex":
+            tex_file = tex_file.with_suffix(".tex")
+        tex_file = tex_dir / tex_file.name
+        tex_file.write_text(latex_code, encoding="utf-8")
 
-        ret = subprocess.run([
-            "pdflatex",
-            f"-output-directory={pdf_path_}",
-            texfile,     
-        ], capture_output=True)
-        if ret.returncode != 0:
-            print(ret.stdout.decode())
-            print(ret.stderr.decode())
-            raise RuntimeError("LaTeX compilation failed!")
-        
-        os.remove(pdf_path / filename.replace(".tex", ".aux"))
-        os.remove(pdf_path / filename.replace(".tex", ".log"))
+        result = subprocess.run(
+            [
+                engine,
+                f"-output-directory={str(pdf_dir).replace(os.sep, '/')}",
+                str(tex_file).replace(os.sep, "/"),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                "LaTeX compilation failed:\n"
+                + result.stdout
+                + ("\n" + result.stderr if result.stderr else "")
+            )
 
+        pdf_file = pdf_dir / tex_file.with_suffix(".pdf").name
+        for suffix in (".aux", ".log"):
+            aux_file = pdf_dir / tex_file.with_suffix(suffix).name
+            if aux_file.exists():
+                aux_file.unlink()
+        return pdf_file

--- a/pyqres/quantikz/visitor.py
+++ b/pyqres/quantikz/visitor.py
@@ -1,74 +1,126 @@
+from __future__ import annotations
+
 from ..core.metadata import RegisterMetadata
+from ..core.operation import Primitive
 from ..core.utils import merge_controllers
-from .generator import QuantumCircuit, OpCode, Controller, LatexGenerator
+from .generator import Controller, LatexGenerator, OpCode, QuantumCircuit
 
 
 class QuantikzVisitor:
-    """Visitor that converts an Operation tree into a LaTeX quantum circuit diagram."""
+    """Visitor that converts a pyqres Operation tree to Quantikz LaTeX.
 
-    def __init__(self):
-        registers = RegisterMetadata.get_registers()
-        self.circuit = QuantumCircuit(registers)
-        self._skip = None
+    Traversal still comes from ``Operation.traverse`` so dagger propagation,
+    reversed dagger traversal, controller contexts, and temporary register
+    scopes stay aligned with the rest of pyqres.
+    """
+
+    _CONTROL_TYPES = (
+        "conditioned_by_all_ones",
+        "conditioned_by_nonzero",
+        "conditioned_by_bit",
+        "conditioned_by_value",
+    )
+
+    def __init__(self, registers=None):
+        self.circuit = QuantumCircuit(registers or RegisterMetadata.get_registers())
 
     def enter(self, node):
-        if self._skip:
-            return
+        self._sync_register_metadata()
 
     def exit(self, node):
-        if id(node) == self._skip:
-            self._skip = None
+        pass
 
     def visit(self, node, dagger_ctx=False, controllers_ctx=None):
+        if not isinstance(node, Primitive):
+            return
+
         controllers_ctx = controllers_ctx or {}
+        self._sync_register_metadata()
+        if self._handle_register_primitive(node, dagger_ctx, controllers_ctx):
+            return
 
-        if hasattr(node, 'pyqsparse_object'):
-            op_code = self._primitive_to_opcode(node, dagger_ctx, controllers_ctx)
-            if op_code is not None:
-                self.circuit.add_op(op_code)
-            self._skip = id(node)
-        elif hasattr(node, 'program_list'):
-            # Register ops like SplitRegister/CombineRegister
-            self._handle_register_op(node, dagger_ctx, controllers_ctx)
-            self._skip = id(node)
+        self.circuit.add_op(self._primitive_to_opcode(node, dagger_ctx, controllers_ctx))
 
-    def _primitive_to_opcode(self, node, dagger_ctx=False, controllers_ctx=None):
-        merged = merge_controllers(node.controllers, controllers_ctx or {})
-        dagger = dagger_ctx ^ node.dagger_flag
+    def _sync_register_metadata(self) -> None:
+        metadata = RegisterMetadata.get_register_metadata()
+        reg_types = metadata.register_types
+        for name, size in metadata.registers.items():
+            self.circuit.ensure_register(str(name), size, reg_types.get(name, "General"))
 
-        name = node.name
-        targets = list(node.reg_list)
-        params = list(node.param_list)
-
-        controls = self._build_controls(merged)
-
+    def _primitive_to_opcode(self, node, dagger_ctx=False, controllers_ctx=None) -> OpCode:
+        merged = merge_controllers(controllers_ctx or {}, node.controllers)
+        dagger = bool(dagger_ctx ^ node.dagger_flag)
         return OpCode(
-            name=name,
-            targets=targets,
-            params=params,
-            controls=controls,
+            name=node.name,
+            targets=[str(reg) for reg in node.reg_list],
+            params=list(node.param_list),
+            controls=self._build_controls(merged),
             dagger=dagger,
         )
 
+    def _handle_register_primitive(self, node, dagger_ctx=False, controllers_ctx=None) -> bool:
+        name = node.__class__.__name__
+        effective_dagger = bool(dagger_ctx ^ getattr(node, "dagger_flag", False))
+        merged = merge_controllers(controllers_ctx or {}, node.controllers)
+        controls = self._build_controls(merged)
+
+        if name == "SplitRegister":
+            op_name = "CombineRegister" if effective_dagger else "SplitRegister"
+            self.circuit.add_op(
+                OpCode(
+                    name=op_name,
+                    targets=[str(reg) for reg in node.reg_list],
+                    params=list(node.param_list),
+                    controls=controls,
+                )
+            )
+            return True
+
+        if name == "CombineRegister":
+            op_name = "SplitRegister" if effective_dagger else "CombineRegister"
+            self.circuit.add_op(
+                OpCode(
+                    name=op_name,
+                    targets=[str(reg) for reg in node.reg_list],
+                    params=list(node.param_list),
+                    controls=controls,
+                )
+            )
+            return True
+
+        if name in ("AddRegister", "AddRegisterWithHadamard"):
+            reg_name = str(node.param_list[0])
+            reg_type = str(node.param_list[1])
+            size = node.param_list[2]
+            self.circuit.ensure_register(reg_name, size, reg_type)
+            self.circuit.add_op(
+                OpCode(
+                    name=name,
+                    targets=[reg_name],
+                    params=[reg_type, size],
+                    controls=controls,
+                )
+            )
+            return True
+
+        if name == "RemoveRegister":
+            reg_name = str(node.param_list[0])
+            self.circuit.ensure_register(reg_name)
+            self.circuit.add_op(OpCode(name=name, targets=[reg_name], controls=controls))
+            return True
+
+        return False
+
     def _build_controls(self, controllers_ctx):
         controls = []
-        for ctype in ('conditioned_by_all_ones', 'conditioned_by_nonzero',
-                       'conditioned_by_bit', 'conditioned_by_value'):
-            if ctype in controllers_ctx:
-                for entry in controllers_ctx[ctype]:
-                    if isinstance(entry, tuple):
-                        reg, info = entry[0], entry[1]
-                        controls.append(Controller(qreg=reg, control_type=ctype, control_info=info))
-                    else:
-                        controls.append(Controller(qreg=entry, control_type=ctype))
+        for ctype in self._CONTROL_TYPES:
+            for entry in controllers_ctx.get(ctype, []):
+                if isinstance(entry, tuple):
+                    reg, info = entry[0], entry[1]
+                    controls.append(Controller(str(reg), ctype, info))
+                else:
+                    controls.append(Controller(str(entry), ctype))
         return controls
-
-    def _handle_register_op(self, node, dagger_ctx, controllers_ctx):
-        name = node.name
-        if name == 'SplitRegister':
-            self.circuit.split_registers(node.reg_list, node.param_list)
-        elif name == 'CombineRegister':
-            self.circuit.merge_registers(node.reg_list, node.param_list)
 
     def to_latex(self):
         return LatexGenerator.generate(self.circuit)

--- a/tests/test_quantikz.py
+++ b/tests/test_quantikz.py
@@ -2,14 +2,11 @@
 
 import pytest
 
-from pyqres.core.operation import Primitive, Composite, StandardComposite
 from pyqres.core.metadata import RegisterMetadata
-from pyqres.quantikz import QuantikzVisitor, LatexGenerator
-from pyqres.primitives import (
-    Hadamard, X, CNOT, Toffoli,
-    Swap_General_General, SplitRegister,
-)
+from pyqres.core.operation import StandardComposite
 from pyqres.generated import Swap
+from pyqres.primitives import CNOT, Hadamard, SplitRegister, Toffoli, X
+from pyqres.quantikz import LatexGenerator, OpCode, QuantikzVisitor, QuantumCircuit
 
 
 def declare_regs(**regs):
@@ -77,6 +74,22 @@ class TestCompositeLatex:
         assert r'\mathrm{Hadamard}' in latex
         assert r'\mathrm{X}' in latex
 
+    def test_controlled_composite_propagates_to_children(self):
+        class ControlledBody(StandardComposite):
+            def __init__(self):
+                super().__init__(reg_list=['ctrl', 'q'])
+                self.program_list = [X(['q'], [0])]
+                self.declare_program_list()
+
+        declare_regs(ctrl=1, q=1)
+        op = ControlledBody().control_by_bit([('ctrl', 0)])
+        vis = QuantikzVisitor()
+        op.traverse(vis)
+        latex = vis.to_latex()
+
+        assert r'\ctrl[open]{' in latex
+        assert r'\mathrm{X}' in latex
+
 
 class TestDaggerLatex:
     def test_dagger_marker(self):
@@ -88,6 +101,23 @@ class TestDaggerLatex:
         latex = vis.to_latex()
         assert r'\dagger' in latex
 
+    def test_dagger_composite_reverses_children_and_marks_each_gate(self):
+        class TwoGateBody(StandardComposite):
+            def __init__(self):
+                super().__init__(reg_list=['q'])
+                self.program_list = [Hadamard(['q']), X(['q'], [0])]
+                self.declare_program_list()
+
+        declare_regs(q=1)
+        op = TwoGateBody().dagger()
+        vis = QuantikzVisitor()
+        op.traverse(vis)
+        latex = vis.to_latex()
+
+        assert latex.index(r'\mathrm{X}^{\dagger}') < latex.index(
+            r'\mathrm{Hadamard}^{\dagger}'
+        )
+
 
 class TestSplitRegister:
     def test_split_in_circuit(self):
@@ -97,6 +127,24 @@ class TestSplitRegister:
         SplitRegister(['parent', 'child1', 'child2'], [2, 2]).traverse(vis)
         latex = vis.to_latex()
         assert 'quantikz' in latex
+        assert r'\mathrm{SplitRegister}' in latex
+
+    def test_split_can_introduce_register_rows(self):
+        declare_regs(parent=2)
+        vis = QuantikzVisitor()
+        SplitRegister(['parent', '_overflow'], [1]).traverse(vis)
+        latex = vis.to_latex()
+
+        assert r'\_overflow' in latex
+        assert r'\qwbundle{1}' in latex
+
+    def test_register_names_are_latex_escaped(self):
+        declare_regs(_overflow=1)
+        vis = QuantikzVisitor()
+        X(['_overflow'], [0]).traverse(vis)
+        latex = vis.to_latex()
+
+        assert r'\_overflow' in latex
 
 
 class TestControlTypes:
@@ -137,3 +185,11 @@ class TestLatexOutput:
         latex = vis.to_latex_figure("Test circuit")
         assert r'\begin{figure}' in latex
         assert r'\caption{Test circuit}' in latex
+
+    def test_direct_quantum_circuit_api_still_works(self):
+        circuit = QuantumCircuit({'q': 1})
+        circuit.add_op(OpCode(name='X', targets=['q'], params=[0]))
+        latex = LatexGenerator.generate(circuit)
+
+        assert r'\mathrm{X}' in latex
+        assert latex.startswith(r'\documentclass{standalone}')


### PR DESCRIPTION
## Summary
- replace the legacy permutation-based Quantikz renderer with a register-level timeline renderer
- make QuantikzVisitor compile pyqres Operation trees with controller and dagger traversal semantics
- allow SplitRegister metadata to introduce target registers, which fixes QDA-Tridiagonal _overflow/_other rendering
- update docs and README for the restored Quantikz workflow

## Validation
- env UV_CACHE_DIR=/tmp/uv-cache uv run --with pytest pytest tests/test_quantikz.py tests/test_visualization_html.py
- env UV_CACHE_DIR=/tmp/uv-cache uv run --with pytest pytest tests/test_primitives.py tests/test_simulation.py tests/test_algorithms_e2e.py::TestQDATridiagonal::test_block_encoding_tridiagonal_simulation
- env UV_CACHE_DIR=/tmp/uv-cache uv run --with ruff ruff check pyqres/quantikz pyqres/core/metadata.py tests/test_quantikz.py
- env UV_CACHE_DIR=/tmp/uv-cache MPLCONFIGDIR=/tmp/mplconfig uv run --with-requirements docs/requirements.txt sphinx-build -b html docs/source docs/build/html