### PR TITLE
[codex] Add pyqres QEC workflow integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,46 @@
 # Quantum-Resource-Estimator (pyqres)
 
-Quantum-Resource-Estimator is a register-level quantum algorithm programming
-and resource-estimation toolkit.  The current project focus is to use pyqres as
-the algorithm authoring layer for QEC-Compiler integration: algorithms are
-written as pyqres `Operation` trees, verified with PySparQ when possible,
-visualized as interactive HTML, and lowered to QEC-Compiler `AbstractCircuit`
-through a small intermediate primitive contract.
+Quantum-Resource-Estimator is a register-level quantum algorithm authoring,
+simulation, resource-estimation, and QEC-Compiler integration toolkit.
+
+The current project focus is larger than coarse resource estimation: pyqres is
+the algorithm entry point in a three-project workflow. Algorithms are written as
+YAML-generated or hand-written pyqres `Operation` trees, verified with PySparQ
+when a faithful reference exists, lowered to QEC-Compiler `AbstractCircuit`, and
+then compiled into QEC-level layout/schedule/QEOL artifacts.
+
+```text
+pyqres YAML DSL / Python Operation tree
+  -> PySparQ register-level simulation when supported
+  -> pyqres QEC lowering
+  -> QEC-Compiler AbstractCircuit
+  -> logical lowering / lattice surgery / QEOL JSON
+```
 
 ## What It Does
 
-- Defines quantum programs as an `Operation` tree with `Primitive` and
-  `Composite` nodes.
-- Supports controller and dagger propagation through the tree.
-- Provides a YAML DSL that compiles composite operation schemas to Python
-  classes under `pyqres.generated`.
+- Defines quantum programs as `Operation` trees with `Primitive` and `Composite` nodes.
+- Compiles YAML DSL composite schemas to Python classes under `pyqres.generated`.
+- Supports controller and dagger propagation through operation trees.
 - Runs register-level simulation through PySparQ for supported primitives.
-- Estimates coarse `T-count`, `T-depth`, `Toffoli-count`, and
-  `Toffoli-depth`.
+- Estimates coarse `T-count`, `T-depth`, `Toffoli-count`, and `Toffoli-depth`.
 - Emits interactive HTML call-tree and register-level circuit visualizations.
 - Lowers supported operations to QEC-Compiler `AbstractCircuit`.
+- Provides YAML mirrors of QEC-Compiler benchmark examples for gate-level parity tests.
 
 ## Repository Layout
 
 ```text
 pyqres/
   core/                  Operation, visitors, metadata, lowering
-  primitives/            PySparQ-facing and QEC intermediate primitives
-  algorithms/            Hand-written algorithms such as Shor, QDA, CKS, Grover
+  primitives/            PySparQ-facing primitives and QEC intermediate primitives
+  algorithms/            Hand-written algorithms and QEC example helpers
   dsl/                   YAML schema validation and code generation
   generated/             DSL-generated operation classes
   visualization/         Standalone HTML call-tree and circuit renderers
 docs/source/             Sphinx documentation
 examples/                Small runnable examples
-tests/                   Unit, integration, QEC lowering, and visualization tests
+tests/                   Unit, integration, QEC lowering, YAML mirror, visualization tests
 ```
 
 ## Install
@@ -45,179 +53,181 @@ source .venv/bin/activate
 pip install -e ".[test]"
 ```
 
-`pysparq` is installed from the QRAM-Simulator repository as declared in
-`pyproject.toml`.  QEC integration tests additionally require
-`qec_compiler` to be importable, either by installing QEC-Compiler or by adding
-its checkout to `PYTHONPATH`.
+`pysparq` is installed from QRAM-Simulator as declared in `pyproject.toml`.
+QEC integration additionally requires `qec_compiler` to be importable. In a
+side-by-side checkout, use:
 
-## Minimal Example
+```bash
+PYTHONPATH=../QEC-compiler/src:. .venv/bin/python your_script.py
+```
+
+QEC-Compiler itself uses `uv`:
+
+```bash
+cd ../QEC-compiler
+uv venv
+source .venv/bin/activate
+uv sync --all-extras
+```
+
+## Minimal Simulation Example
 
 ```python
+import pysparq as ps
+
 from pyqres.core.metadata import RegisterMetadata
 from pyqres.core.simulator import SimulatorVisitor
 from pyqres.primitives import Hadamard, X
 
-RegisterMetadata.get_register_metadata().declare_register("q", 2)
+rm = RegisterMetadata.get_register_metadata()
+rm.declare_register("q", 2, "UnsignedInteger")
 
 sim = SimulatorVisitor()
 Hadamard(["q"]).traverse(sim)
 X(["q"], [0]).traverse(sim)
 
-print(sim.state.size())
+print(ps.StatePrint(sim.state, ps.StatePrintDisplay.Detail))
 ```
 
-## CLI
-
-```bash
-# Compile YAML DSL schemas to Python classes
-pyqres compile
-
-# Check schema dependency coverage
-pyqres check
-
-# Inspect an operation dependency tree
-pyqres show Swap --depth 3
-
-# Estimate coarse resources
-pyqres estimate Toffoli
-pyqres estimate Toffoli -m t_depth
-pyqres estimate Add_UInt_UInt -r a:4,b:4,c:4
-```
-
-See `docs/source/cli/index.rst` for the full CLI reference.
-
-## YAML DSL
-
-Composite operations are described in YAML and compiled to Python classes.
-Built-in schemas live under:
-
-```text
-pyqres/dsl/schemas/composites/
-pyqres/dsl/schemas/primitives/
-pyqres/lib/
-```
-
-Example shape:
-
-```yaml
-name: MyOperation
-description: "Small composite operation"
-qregs:
-  - {name: q, type: General}
-params:
-  - {name: repeats, type: int}
-impl:
-  - loop:
-      iterations: repeats
-      body:
-        - op: Hadamard
-          qregs: [q]
-```
-
-The DSL supports register declarations, classical parameters, temporary
-registers, loops, reverse loops, `for_each`, Python-level `if`/`elif`/`else`,
-inline Python blocks, operation comments, controllers, and dagger annotations.
-The detailed schema reference is in `docs/source/defining_operations/` and
-`docs/source/dsl_schema/`.
-
-## QEC-Compiler Integration
-
-The recommended entry point is:
+## Minimal QEC Lowering Example
 
 ```python
 from pyqres.core.lowering import to_abstract_circuit
 from pyqres.core.metadata import RegisterMetadata
-from pyqres.primitives import Hadamard
+from pyqres.primitives import Hadamard, CNOT
 
-RegisterMetadata.get_register_metadata().declare_register("q", 1)
-circuit = to_abstract_circuit(Hadamard(["q"]))
+rm = RegisterMetadata.get_register_metadata()
+rm.declare_register("q0", 1, "Boolean")
+rm.declare_register("q1", 1, "Boolean")
+
+class BellProgram:
+    def __init__(self):
+        self.program_list = [Hadamard(["q0"]), CNOT(["q0", "q1"], [0, 0])]
+
+    def traverse(self, visitor, dagger_ctx=False, controllers_ctx=None):
+        for op in self.program_list:
+            op.traverse(visitor, dagger_ctx, controllers_ctx or {})
+
+circuit = to_abstract_circuit(BellProgram())
+print(circuit.num_qubits)
+print([gate.name for gate in circuit.gates])
 ```
 
-Lowering is implemented by `pyqres.core.qec_lowering.QECLoweringVisitor`.
-Unsupported primitives fail closed with `UnsupportedQECPrimitive` instead of
-silently becoming no-ops.
+## YAML DSL
 
-The frozen first-pass intermediate primitive set is:
+Compile built-in YAML schemas:
+
+```bash
+pyqres compile
+pyqres check
+pyqres show QECExampleQFT --depth 2
+```
+
+Example composite:
+
+```yaml
+- name: QECExampleQFT
+  qregs:
+    - {name: q, type: General}
+  params:
+    - {name: n, type: int}
+  impl:
+    - python: |
+        from ..algorithms.qec_examples import build_qec_qft
+    - python: |
+        build_qec_qft(self.program_list, self.q, self.n)
+```
+
+The generated class can lower to QEC-Compiler `AbstractCircuit`:
+
+```python
+from pyqres.core.lowering import to_abstract_circuit
+from pyqres.core.metadata import RegisterMetadata
+from pyqres.generated import QECExampleQFT
+
+RegisterMetadata.get_register_metadata().declare_register("q", 4, "General")
+circuit = to_abstract_circuit(QECExampleQFT(["q"], [4]))
+```
+
+## Supported Algorithm Workflows
+
+Gate-level YAML mirrors currently match QEC-Compiler benchmark builders for:
+
+- GHZ and W-state preparation
+- Bernstein-Vazirani and Deutsch-Jozsa
+- Grover
+- QFT and QPE
+- QAOA, VQE, and Ising
+- SWAP-test
+- small Shor fixtures for `N=15` and `N=21`
+
+Register-level algorithm workflows include:
+
+- `BlockEncodingTridiagonal`
+- generated `QDALinearSolver` with tridiagonal block encoding
+- hand-written Shor / `ExpMod` lowering via `CMUL_MOD_N`
+- intermediate arithmetic primitives: `MCX`, `PLUS_ONE`, `ADD`, `REFLECT`, `MOD_ADD`, `MOD_MUL`
+
+QDA-tridiagonal is tested for multiple matrix sizes (`main_bits = 1, 2, 3`) through
+`AbstractCircuit` lowering and QEC logical lowering.
+
+## QEC Intermediate Contract
+
+The first shared primitive contract with QEC-Compiler includes:
 
 | pyqres primitive | QEC gate family | Notes |
 |---|---|---|
 | `MCX` | `MCX` | Multi-control X. |
-| `PLUS_ONE` | `PLUS_ONE`, `PLUS_ONE_DAG`, `CPLUS_ONE`, `CPLUS_ONE_DAG` | Modular increment/decrement. |
+| `PLUS_ONE` | `PLUS_ONE`, `PLUS_ONE_DAG`, `CPLUS_ONE`, `CPLUS_ONE_DAG` | Increment/decrement modulo `2^n`. |
 | `ADD` | `ADD`, `ADD_DAG`, `CADD`, `CADD_DAG` | Equal-width in-place addition modulo `2^n`. |
 | `REFLECT` | `REFLECT` | Multi-controlled phase reflection. |
 | `MOD_ADD` | `MOD_ADD`, `MOD_SUB`, `CMOD_ADD`, `CMOD_SUB` | Clean modular add/subtract on the valid subspace. |
 | `MOD_MUL` | `MOD_MUL`, `CMOD_MUL` | Clean modular multiply; dagger uses `c^-1 mod N`. |
+| `QECGate` | arbitrary QEC gate name | Compiler-only adapter for YAML benchmark mirrors. |
 
-Shor `ExpMod` still emits the compatibility gate `CMUL_MOD_N`.  The full
-contract is documented in `docs/source/api/qec_intermediate_contract.rst`.
+Shor `ExpMod` emits the compatibility gate `CMUL_MOD_N`.
 
-## Visualization
+## QRAM Status
 
-pyqres can write standalone HTML visualizations for an already constructed
-operation object.  The files contain inline CSS and JavaScript and can be
-opened directly in a browser.
+pyqres QRAM wrappers are intentionally disabled in the current QEC workflow:
 
-```python
-from pyqres.algorithms.block_encoding import BlockEncodingTridiagonal
-from pyqres.core.metadata import RegisterMetadata
-from pyqres.visualization import write_call_tree_html, write_circuit_html
+- `QRAM.pyqsparse_object()` raises `NotImplementedError`.
+- `QRAMFast.pyqsparse_object()` raises `NotImplementedError`.
+- `t_count()` for QRAM wrappers also raises `NotImplementedError`.
 
-rm = RegisterMetadata.get_register_metadata()
-rm.declare_register("main", 2, "UnsignedInteger")
-rm.declare_register("anc_UA", 4, "UnsignedInteger")
-
-op = BlockEncodingTridiagonal(
-    main_reg="main",
-    anc_UA="anc_UA",
-    alpha=0.5,
-    beta=0.3,
-)
-
-write_call_tree_html(op, "block_encoding_tree.html")
-write_circuit_html(op, "block_encoding_circuit.html")
-```
-
-The circuit view supports expansion depth and per-module expansion overrides.
-For a QDA-Tridiagonal example:
-
-```bash
-python examples/qda_tridiagonal_visualization.py
-```
-
-For LaTeX output, `pyqres.quantikz.QuantikzVisitor` compiles an `Operation`
-tree into register-level Quantikz:
-
-```python
-from pyqres.quantikz import QuantikzVisitor
-
-visitor = QuantikzVisitor()
-op.traverse(visitor)
-latex = visitor.to_latex()
-```
-
-See `docs/source/visualization/index.rst` for details.
+Direct PySparQ QRAM experiments are still possible outside pyqres. The pyqres
+QRAM contract will be defined later.
 
 ## Tests And Docs
 
 ```bash
-pytest -q
-pytest tests/test_qec_lowering.py tests/test_qec_shor.py -q
-pytest tests/test_visualization_html.py -q
+# pyqres targeted integration
+PYTHONPATH=../QEC-compiler/src:. .venv/bin/pytest \
+  tests/test_qec_examples_yaml.py \
+  tests/test_qec_lowering.py \
+  tests/test_intermediate_semantics.py \
+  tests/test_qram_unimplemented.py -q
+
+# QEC arithmetic side
+cd ../QEC-compiler
+.venv/bin/python -m pytest \
+  tests/test_arithmetic_decomposition.py \
+  tests/test_arithmetic_truth_table.py -q
+
+# docs
+cd ../Quantum-Resource-Estimator
 sphinx-build -b html docs/source docs/_build/html
 ```
-
-If `qec_compiler` is not importable, cross-repository QEC tests are skipped by
-design in standalone pyqres environments.
 
 ## Documentation
 
 The Sphinx documentation is the source of truth for detailed usage:
 
-- `docs/source/getting_started/`
-- `docs/source/defining_operations/`
-- `docs/source/api/`
-- `docs/source/visualization/`
+- `docs/source/workflow/`
+- `docs/source/defining_operations/yaml_dsl.rst`
+- `docs/source/api/qec_intermediate_contract.rst`
 - `docs/source/simulation/`
+- `docs/source/visualization/`
 
 ## License
 

--- a/docs/source/api/qec_intermediate_contract.rst
+++ b/docs/source/api/qec_intermediate_contract.rst
@@ -1,17 +1,18 @@
 QEC 中间层 Primitive Contract
 =============================
 
-本页冻结 pyqres 与 QEC-compiler 第一版联调用中间层 primitive 的语义。
-pyqres lowering、PySparQ reference simulation、QEC-compiler decomposition 必须共享这些约束。
+本页冻结 pyqres 与 QEC-Compiler 第一版联调用中间层 primitive 的语义。
+pyqres lowering、PySparQ reference simulation、QEC-Compiler decomposition 必须共享这些约束。
 
 通用约定
 --------
 
 * 所有多比特整数寄存器使用 little-endian bit order：bit 0 是最低位。
-* 所有 modular arithmetic 只保证合法子空间语义，输入整数必须满足 ``0 <= x < N``。
+* modular arithmetic 只保证合法子空间语义，输入整数必须满足 ``0 <= x < N``。
 * work、flag、predicate 等辅助 qubit 必须以 ``|0>`` 输入，并在操作结束后恢复到 ``|0>``。
 * 不支持的 controlled 或 dagger lowering 必须显式报错，不能静默忽略控制条件或逆操作。
 * composite dagger 使用标准规则：反向遍历 children，并对每个 child 应用 dagger context。
+* PySparQ reference 必须语义等价；没有等价实现时必须抛 ``NotImplementedError``。
 
 Primitive 语义
 --------------
@@ -32,6 +33,7 @@ Primitive 语义
 ``MOD_ADD(a, b; N)``
     合法子空间 ``a,b < N`` 上执行 ``|a>|b>|0> -> |a>|a + b mod N>|0>``。
     dagger 为 ``|a>|b>|0> -> |a>|b - a mod N>|0>``。
+    pyqres QEC lowering 会自动分配一个 clean flag ancilla，并计入 ``AbstractCircuit.num_qubits``。
 
 ``MOD_MUL(x; c, N)``
     合法子空间 ``x < N`` 且 ``gcd(c, N) = 1`` 时执行
@@ -43,7 +45,7 @@ QEC gate 变体
 
 pyqres 公开的中间层 Python primitive 固定为 ``MCX``、``PLUS_ONE``、
 ``ADD``、``REFLECT``、``MOD_ADD``、``MOD_MUL``。在 lowering 到
-QEC-compiler ``AbstractCircuit`` 时，controller 与 dagger context 会被显式
+QEC-Compiler ``AbstractCircuit`` 时，controller 与 dagger context 会被显式
 编码为 QEC gate 名称，而不是被静默消去：
 
 * ``PLUS_ONE_DAG`` / ``CPLUS_ONE`` / ``CPLUS_ONE_DAG``
@@ -52,9 +54,9 @@ QEC-compiler ``AbstractCircuit`` 时，controller 与 dagger context 会被显�
 * ``CMOD_MUL``；``MOD_MUL`` 的 dagger 通过 ``c^-1 mod N`` 改写 multiplier
 
 controlled gate 的 qubit 顺序统一为 ``controls...`` 后接原 primitive qubit。
-``C*`` gate 的最后一个参数是 ``n_controls``，用于 QEC-compiler 从 qubit 列表
+``C*`` gate 的最后一个参数是 ``n_controls``，用于 QEC-Compiler 从 qubit 列表
 中拆分外部控制位。value-control 为 0 时，pyqres lowering 会在控制位前后插入
-``X`` sandwich，使 QEC-compiler 仍只需要识别 all-ones control。
+``X`` sandwich，使 QEC-Compiler 仍只需要识别 all-ones control。
 
 ``CMUL_MOD_N(control, x; c, N)``
     Shor ``ExpMod`` 的兼容 gate。control 为 1 时执行 ``MOD_MUL``，否则 no-op。
@@ -62,9 +64,59 @@ controlled gate 的 qubit 顺序统一为 ``controls...`` 后接原 primitive qu
     modular multiplication 使用 ``CMOD_MUL``。QEC lowering 可以为 work/flag
     分配 clean auxiliary qubit。
 
-PySparQ reference 要求
---------------------------
+QECGate adapter
+---------------
 
-pyqres 中间层 primitive 的 ``pyqsparse_object()`` 必须与上述 contract 一致。
-如果 PySparQ 暂无等价 primitive，则该 reference 必须抛出 ``NotImplementedError``，
-直到补齐正确实现；不能使用语义不同的 primitive 作为占位。
+``QECGate`` 是 compiler-only adapter，用于 YAML-defined QEC-Compiler example mirrors。
+它的参数结构是：
+
+.. code-block:: python
+
+   QECGate(reg_list=["q"], param_list=[gate_name, qubits, params])
+
+例如：
+
+.. code-block:: python
+
+   QECGate(reg_list=["q"], param_list=["CNOT", [0, 1], []])
+
+会发出 QEC-Compiler ``AbstractGate(name="CNOT", qubits=(0, 1), params=())``。
+
+``QECGate`` 不属于算法 semantic primitive：
+
+* ``pyqsparse_object()`` 抛 ``NotImplementedError``。
+* ``t_count()`` 抛 ``NotImplementedError``。
+* 它只用于验证 ``YAML DSL -> generated Python -> AbstractCircuit`` 的 gate-level parity。
+
+PySparQ reference 状态
+---------------------
+
+.. list-table::
+   :widths: 24 28 48
+   :header-rows: 1
+
+   * - Primitive
+     - PySparQ reference
+     - 说明
+   * - ``MCX`` / ``ADD`` / ``PLUS_ONE`` / ``REFLECT``
+     - 有参考路径或可由现有 PySparQ primitive 表达
+     - 用于小规模语义 smoke。
+   * - ``MOD_ADD``
+     - 暂无
+     - 必须抛 ``NotImplementedError``，不能用普通 add 冒充 modular add。
+   * - ``MOD_MUL``
+     - 有 PySparQ modular multiplication reference
+     - dagger 使用 modular inverse multiplier。
+   * - ``QECGate``
+     - 无
+     - compiler-only adapter。
+   * - ``QRAM`` / ``QRAMFast``
+     - 当前禁用
+     - pyqres wrappers 全部显式抛 ``NotImplementedError``。
+
+QRAM 策略
+---------
+
+QRAM 暂时不进入 pyqres/QEC 联调主线。直接 PySparQ QRAM 实验仍可进行，但 pyqres
+``QRAM`` 和 ``QRAMFast`` wrapper 不提供 dummy memory、不提供 T-count 占位、不提供 QEC lowering。
+未来需要单独定义 address/data width、memory layout、load/unload、clean ancilla 和 QEC resource contract。

--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -1,71 +1,95 @@
 命令行工具
 ==========
 
-Quantum-Resource-Estimator 提供 ``pyqres`` 命令行工具。
+Quantum-Resource-Estimator 提供 ``pyqres`` 命令行工具，用于编译 YAML DSL、检查 schema
+依赖、查看 operation tree 和运行 coarse resource estimation。
 
 compile
 -------
 
-编译 YAML schema 生成 Python 代码：
+编译 YAML composite schema 生成 Python 类：
 
 .. code-block:: bash
 
-   # 编译默认 schemas
+   # 编译默认 schemas 到 pyqres/generated/
    pyqres compile
 
    # 指定源和输出路径
-   pyqres compile --source pyqres/dsl/schemas/primitives/ --output pyqres/generated/
+   pyqres compile --source pyqres/dsl/schemas/composites/qec_examples.yml --output /tmp/generated
+
+默认会读取：
+
+.. code-block:: text
+
+   pyqres/dsl/schemas/composites/
+
+生成文件写入：
+
+.. code-block:: text
+
+   pyqres/generated/
+
+当前内置 schema 包括基础 composite、Grover/QPE/QDA/Shor 等算法，以及
+``QECExample*`` benchmark mirrors。
 
 check
 -----
 
-检查操作定义的完整性：
+检查操作定义完整性：
 
 .. code-block:: bash
 
    pyqres check
 
-检查内容：
+检查内容包括：
 
-- 依赖图构建与缺失检测
-- 循环依赖检测
-- 覆盖率报告
+* operation 引用是否存在。
+* qreg/param/controller 引用是否在当前 schema 中声明。
+* composite 依赖覆盖情况。
 
 show
 ----
 
-显示操作的依赖树：
+显示 operation 依赖树：
 
 .. code-block:: bash
 
-   # 显示操作树
-   pyqres show Swap
-
-   # 限制深度
    pyqres show Swap --depth 3
+   pyqres show QECExampleQFT --depth 2
+   pyqres show QDALinearSolver --depth 3
+
+``QECExample*`` 类通常通过 Python helper 和 ``QECGate`` 生成 gate sequence，因此 dependency tree
+主要用于确认 YAML class 已经注册。
 
 estimate
 --------
 
-估计操作的资源消耗：
+估计操作的 coarse resource：
 
 .. code-block:: bash
 
-   # 估计 T-count（默认）
    pyqres estimate Toffoli
-
-   # 指定寄存器大小
-   pyqres estimate Add_UInt_UInt -r a:4,b:4,c:4
-
-   # 估计 T-depth
    pyqres estimate Toffoli -m t_depth
-
-   # 估计 Toffoli-count
-   pyqres estimate Mult_UInt_ConstUInt -r a:4,b:4 -p const:5 -m toffoli_count
+   pyqres estimate Add_UInt_UInt -r a:4,b:4,c:4
 
 参数说明：
 
-- ``operation`` — 操作名称（必须存在于 OperationRegistry）
-- ``-r, --registers`` — 寄存器定义，格式为 ``name:size,name:size,...``
-- ``-p, --params`` — 参数定义，格式为 ``name:value,name:value,...``
-- ``-m, --metric`` — 资源指标：``t_count``（默认）、``t_depth``、``toffoli_count``
+* ``operation``：操作名称，必须存在于 ``OperationRegistry``。
+* ``-r, --registers``：寄存器定义，格式为 ``name:size,name:size,...``。
+* ``-p, --params``：参数定义，格式为 ``name:value,name:value,...``。
+* ``-m, --metric``：资源指标，支持 ``t_count``、``t_depth``、``toffoli_count``。
+
+注意：``QECGate`` 和 QRAM wrappers 不提供 pyqres resource estimator 语义。
+``QECGate`` 用于 ``AbstractCircuit`` emission；QRAM 当前显式 ``NotImplementedError``。
+
+QEC examples mirror 工作流
+-------------------------
+
+.. code-block:: bash
+
+   pyqres compile
+   pyqres check
+   PYTHONPATH=../QEC-compiler/src:. .venv/bin/pytest tests/test_qec_examples_yaml.py -q
+
+该测试验证 YAML-generated ``QECExample*`` 类能生成与 QEC-Compiler benchmark builders
+逐门一致的 ``AbstractCircuit``。

--- a/docs/source/defining_operations/yaml_dsl.rst
+++ b/docs/source/defining_operations/yaml_dsl.rst
@@ -1,39 +1,35 @@
 YAML DSL
 ========
 
-Quantum-Resource-Estimator 使用 YAML 作为操作定义的 schema 格式，支持静态生成 Python 类。
+pyqres YAML DSL 用于定义 ``Composite`` operation。编译器读取 YAML schema，验证依赖，
+生成 Python 类到 ``pyqres.generated``，然后这些类可以像手写 ``Operation`` 一样参与
+simulation、resource estimation、visualization 和 QEC lowering。
+
+当前 DSL 是 composite-first：primitive 的 Python 实现位于 ``pyqres.primitives``，
+YAML 负责组合 primitive、控制流程、参数化和少量 Python glue code。
 
 基本流程
 --------
 
-::
+.. code-block:: text
 
-   YAML Schema → SchemaValidator → CodeGenerator → generated/*.py
+   YAML composite schema
+      -> SchemaValidator
+      -> CodeGenerator
+      -> pyqres/generated/*.py
+      -> OperationRegistry auto registration
+      -> Operation tree traversal
 
-1. 在 ``pyqres/dsl/schemas/`` 下编写 YAML 文件
-2. 运行 ``pyqres compile`` 编译
-3. 生成的 Python 类自动注册到 OperationRegistry
+常用命令：
 
-Primitive 定义
+.. code-block:: bash
+
+   pyqres compile
+   pyqres check
+   pyqres show Swap --depth 3
+
+最小示例：Swap
 --------------
-
-.. code-block:: yaml
-
-   - name: Hadamard
-     description: "Hadamard on full register"
-     qregs:
-       - {name: reg, type: General}
-     is_primitive: true
-     pysparq_op: Hadamard_Int_Full
-     pysparq_args: ["$reg"]
-     t_count: |
-       if ncontrols == 0:
-           return 0
-       else:
-           raise NotImplementedError
-
-Composed 定义
--------------
 
 .. code-block:: yaml
 
@@ -49,50 +45,157 @@ Composed 定义
          qregs: [reg2, reg1]
        - op: CNOT
          qregs: [reg1, reg2]
-     traverse_override: cnot_swap
+     control_override: cnot_swap
+     self_conjugate: true
 
-Schema 字段
------------
+使用生成类：
 
-.. list-table::
-   :widths: 20 15 65
-   :header-rows: 1
+.. code-block:: python
 
-   * - 字段
-     - 必选
-     - 说明
-   * - ``name``
-     - 是
-     - 类名（PascalCase）
-   * - ``qregs``
-     - 是
-     - 量子寄存器列表，每项含 name/type
-   * - ``params``
-     - 否
-     - 经典参数列表
-   * - ``temp_regs``
-     - 否
-     - 临时寄存器（enter 声明、exit 移除）
-   * - ``is_primitive``
-     - 否
-     - true = primitive，省略 = composed
-   * - ``pysparq_op``
-     - 原语必选
-     - PySparQ 操作类名，或 ``conditional``
-   * - ``pysparq_args``
-     - 原语必选
-     - 构造参数，``$name`` 引用 qreg/param
-   * - ``t_count``
-     - 原语必选
-     - T-count 公式（Python 代码片段）
-   * - ``impl``
-     - 组合必选
-     - 子操作列表
-   * - ``computed_params``
-     - 否
-     - 从 params 计算的派生属性
-   * - ``traverse_override``
-     - 否
-     - 特殊遍历逻辑标记
+   from pyqres.core.metadata import RegisterMetadata
+   from pyqres.generated import Swap
 
-``$name`` 语法：引用当前操作的 qreg 或 param，生成代码时替换为 ``self.name``。
+   rm = RegisterMetadata.get_register_metadata()
+   rm.declare_register("a", 1, "Boolean")
+   rm.declare_register("b", 1, "Boolean")
+
+   op = Swap(["a", "b"])
+
+循环示例：Grover diffusion 片段
+------------------------------
+
+.. code-block:: yaml
+
+   - comment: "Diffusion: X on all qubits"
+     for_each:
+       var: i
+       items: n_qubits
+       body:
+         - op: X
+           qregs: [search_reg]
+           params: [$i]
+
+``for_each.items`` 如果引用 ``int`` 参数，会生成 ``range(self.n_qubits)``；如果引用
+``array`` 参数，会直接遍历该数组。
+
+控制和 dagger
+-------------
+
+.. code-block:: yaml
+
+   impl:
+     - op: PlusOneOverflow
+       qregs: [main, overflow]
+       params: [1]
+       controllers:
+         value: [[selector, 1]]
+
+     - op: Rot_GeneralStatePrep
+       qregs: [anc]
+       params: [prep_state]
+       dagger: true
+
+支持的 controller 类型：
+
+* ``all_ones: [reg]``
+* ``nonzero: [reg]``
+* ``bit: [[reg, index]]``
+* ``value: [[reg, value]]``
+
+QEC lowering 当前只完整支持一部分 controller 语义；不支持的路径应 fail closed。
+
+computed_params
+---------------
+
+.. code-block:: yaml
+
+   computed_params:
+     - name: p
+       formula: "0.5"
+     - name: n_steps
+       formula: "int(math.ceil(math.log(kappa / epsilon)))"
+
+生成类会把这些公式编译到 ``__init__`` 中，成为 ``self.p``、``self.n_steps``。
+
+inline Python blocks
+--------------------
+
+复杂算法可以使用 ``python`` block 注入少量 glue code。典型用途：导入 helper，或把
+operation 参数转换成 submodule 调用。
+
+.. code-block:: yaml
+
+   impl:
+     - python: |
+         from ..algorithms.qda_solver import compute_fs, WalkS_Primitive
+
+     - loop:
+         iterations: n_steps
+         body:
+           - python: |
+               s = i / max(1, self.n_steps - 1) if self.n_steps > 1 else 1.0
+               fs = compute_fs(s, self.kappa, self.p)
+               self.program_list.append(
+                   WalkS_Primitive(
+                       reg_list=[self.main_reg, self.anc_UA, self.anc_1,
+                                 self.anc_2, self.anc_3, self.anc_4],
+                       param_list=[fs],
+                       submodules=[op for op in [self.encode_A, self.encode_b] if op]))
+
+inline Python 是 escape hatch。应优先用 YAML ``impl``、``loop``、``for_each`` 表达结构，
+只有在算法生成逻辑确实超过 DSL 表达力时再使用。
+
+QEC-Compiler examples YAML mirror
+---------------------------------
+
+为了验证 pyqres YAML DSL 能生成 QEC-Compiler examples 的正确 ``AbstractCircuit``，
+项目提供 ``QECExample*`` 系列：
+
+.. code-block:: text
+
+   pyqres/dsl/schemas/composites/qec_examples.yml
+
+这些 YAML 类通过 compiler-only ``QECGate`` adapter 精确发出 QEC gate：
+
+.. code-block:: python
+
+   QECGate(reg_list=["q"], param_list=["CPHASE", [0, 1], [theta]])
+
+示例：QFT mirror
+
+.. code-block:: yaml
+
+   - name: QECExampleQFT
+     qregs:
+       - {name: q, type: General}
+     params:
+       - {name: n, type: int}
+     impl:
+       - python: |
+           from ..algorithms.qec_examples import build_qec_qft
+       - python: |
+           build_qec_qft(self.program_list, self.q, self.n)
+
+使用：
+
+.. code-block:: python
+
+   from pyqres.core.lowering import to_abstract_circuit
+   from pyqres.core.metadata import RegisterMetadata
+   from pyqres.generated import QECExampleQFT
+
+   RegisterMetadata.get_register_metadata().declare_register("q", 4, "General")
+   circuit = to_abstract_circuit(QECExampleQFT(["q"], [4]))
+
+当前 mirror 覆盖 GHZ、W、BV、DJ、Grover、QFT、QPE、QAOA、VQE、Ising、SWAP-test、small Shor。
+
+注意：``QECGate`` 没有 PySparQ reference，也没有 pyqres T-count。它只用于
+``YAML -> generated Python -> AbstractCircuit`` 的 gate-level parity。
+
+文件组织建议
+------------
+
+* 通用 composite 放在 ``pyqres/dsl/schemas/composites/``。
+* 可复用算法 helper 放在 ``pyqres/algorithms/``。
+* primitive Python 实现放在 ``pyqres/primitives/``。
+* 生成代码只由 ``pyqres compile`` 更新，不手工编辑 ``pyqres/generated/*.py``。

--- a/docs/source/dsl_schema/schema_structure.rst
+++ b/docs/source/dsl_schema/schema_structure.rst
@@ -1,13 +1,14 @@
 YAML Schema 结构
 ================
 
-本页详细说明 YAML schema 的结构和字段。
+本页描述当前 composite YAML schema。primitive set YAML 仅用于 primitive registry/coverage，
+实际 primitive 行为由 ``pyqres.primitives`` 中的 Python 类实现。
 
-完整字段参考
-------------
+顶层字段
+--------
 
 .. list-table::
-   :widths: 20 15 65
+   :widths: 22 14 64
    :header-rows: 1
 
    * - 字段
@@ -15,139 +16,192 @@ YAML Schema 结构
      - 说明
    * - ``name``
      - 是
-     - 类名（PascalCase），如 ``Hadamard``、``Swap``
+     - 生成的 Python 类名，建议 PascalCase。
    * - ``description``
      - 否
-     - 操作描述，用于文档生成
+     - 文档说明，进入生成类 docstring。
    * - ``qregs``
-     - 是
-     - 量子寄存器列表
+     - 否但常用
+     - 量子寄存器声明，生成 ``self.<name>`` 属性。
    * - ``params``
      - 否
-     - 经典参数列表
+     - 经典参数声明，生成 ``self.<name>`` 属性。
    * - ``temp_regs``
      - 否
-     - 临时寄存器（自动生命周期管理）
-   * - ``is_primitive``
-     - 否
-     - ``true`` = primitive，省略 = composed
-   * - ``pysparq_op``
-     - 原语必选
-     - PySparQ 操作类名，或 ``conditional``
-   * - ``pysparq_args``
-     - 原语必选
-     - 构造参数列表，使用 ``$name`` 引用
-   * - ``t_count``
-     - 原语必选
-     - T-count 公式（Python 代码片段）
-   * - ``impl``
-     - 组合必选
-     - 子操作列表
+     - 临时寄存器，Operation enter/exit 时自动声明和移除。
    * - ``computed_params``
      - 否
-     - 派生参数，从 params 计算得到
-   * - ``traverse_override``
+     - 从参数计算派生属性。
+   * - ``impl``
+     - 是
+     - 子操作和控制结构列表。
+   * - ``self_conjugate``
      - 否
-     - 特殊遍历逻辑标记，如 ``cnot_swap``
-   * - ``custom_pyqsparse``
+     - 标记 operation 是否自伴。
+   * - ``control_override``
      - 否
-     - 手写 pyqsparse_object 代码
+     - 特殊控制传播逻辑，如 ``cnot_swap``。
+   * - ``sum_t_count_formula``
+     - 否
+     - ``custom`` 时生成 ``AbstractComposite``，由手写逻辑补充资源聚合。
 
 寄存器声明
 ----------
 
-``qregs`` 和 ``temp_regs`` 的格式：
-
 .. code-block:: yaml
 
    qregs:
-     - {name: reg1, type: General}
-     - {name: reg2, type: UnsignedInteger}
+     - {name: main, type: UnsignedInteger, desc: "Main index register"}
      - {name: flag, type: Boolean}
 
    temp_regs:
      - {name: overflow, size: 1}
-     - {name: ancilla, size: 4}
+     - {name: scratch, size: 4}
 
-寄存器类型：
+支持的 register type：
 
-- ``General`` - 广义量子态
-- ``UnsignedInteger`` - 无符号整数
-- ``SignedInteger`` - 有符号整数
-- ``Boolean`` - 单比特布尔
-- ``Rational`` - 定点有理数
+* ``General``
+* ``UnsignedInteger``
+* ``SignedInteger``
+* ``Boolean``
+* ``Rational``
 
 参数声明
 --------
 
-``params`` 的格式：
-
 .. code-block:: yaml
 
    params:
+     - {name: n, type: int}
      - {name: epsilon, type: float}
-     - {name: kappa, type: symbol}
-     - {name: data, type: array}
+     - {name: edges, type: array}
+     - {name: encode_A, type: operation}
 
-参数类型：
+支持的 param type：
 
-- ``int`` - 整数
-- ``float`` - 浮点数
-- ``symbol`` - SymPy 符号
-- ``array`` - 数组
-- ``object`` - 任意对象
-- ``str`` - 字符串
-- ``bool`` - 布尔值
+* ``int`` / ``float`` / ``symbol`` / ``str`` / ``bool``
+* ``array`` / ``list`` / ``object``
+* ``callable`` / ``operation`` / ``op_instance``
+* ``qram`` / ``qram_ref``，当前仅保留 schema 能力；pyqres QRAM primitive 暂不支持。
 
-子操作列表
-----------
-
-``impl`` 的格式：
+impl: 普通 operation call
+------------------------
 
 .. code-block:: yaml
 
    impl:
+     - op: Hadamard_NDigits
+       qregs: [search_reg]
+       params: [n_qubits]
+
      - op: CNOT
-       qregs: [reg1, reg2]
-     - op: Hadamard
-       qregs: [reg1]
-       dagger: true
-     - op: Add_UInt_UInt
-       qregs: [a, b]
-       params: [epsilon]
-       controllers:
-         all_ones: [ctrl_reg]
+       qregs: [control, target]
+       params: [0, 0]
 
-控制类型
---------
+``qregs`` 引用当前 ``qregs``、``temp_regs`` 或 ``computed_params`` 中声明的名字。
+``params`` 中的字符串如果匹配参数名，会生成 ``self.<param>``。
 
-在 ``controllers`` 中指定：
+impl: loop
+----------
+
+.. code-block:: yaml
+
+   - loop:
+       iterations: n_steps
+       body:
+         - op: X
+           qregs: [main]
+           params: [0]
+
+生成：
+
+.. code-block:: python
+
+   for i in range(self.n_steps):
+       ...
+
+impl: for_each
+--------------
+
+.. code-block:: yaml
+
+   - for_each:
+       var: i
+       items: n_qubits
+       body:
+         - op: X
+           qregs: [search_reg]
+           params: [$i]
+
+如果 ``items`` 是 int 参数，生成 ``range(self.n_qubits)``。如果是 array/list 参数，直接遍历。
+
+impl: if / elif / else
+---------------------
+
+.. code-block:: yaml
+
+   - if:
+       condition: self.beta < 0
+       body:
+         - op: Reflection_Bool
+           qregs: [main]
+           params: [False]
+       else:
+         - op: Hadamard
+           qregs: [main]
+
+condition 是 Python 表达式，生成代码时原样进入方法体。
+
+controllers
+-----------
 
 .. code-block:: yaml
 
    controllers:
-     nonzero: [reg]           # reg 非零时触发
-     all_ones: [reg]          # reg 全 1 时触发
-     bit: [[reg, index]]      # reg 的第 index 位为 1 时触发
-     value: [[reg, val]]      # reg == val 时触发
+     all_ones: [ctrl]
+     bit: [[selector, 0]]
+     value: [[selector, 2]]
 
-示例
-----
+支持 controller 类型：
 
-完整的 Swap 操作定义：
+* ``all_ones``
+* ``nonzero``
+* ``bit``
+* ``value``
+
+QEC lowering 对 controller 的支持范围小于 PySparQ；不支持的 controller 应显式报错。
+
+python block
+------------
 
 .. code-block:: yaml
 
-   - name: Swap
-     description: "通过 3 个 CNOT 交换两个寄存器"
-     qregs:
-       - {name: reg1, type: General}
-       - {name: reg2, type: General}
-     impl:
-       - op: CNOT
-         qregs: [reg1, reg2]
-       - op: CNOT
-         qregs: [reg2, reg1]
-       - op: CNOT
-         qregs: [reg1, reg2]
-     traverse_override: cnot_swap
+   - python: |
+       from ..algorithms.qec_examples import build_qec_qft
+   - python: |
+       build_qec_qft(self.program_list, self.q, self.n)
+
+只有 import-only block 会被 codegen 提升到生成文件顶部；非 import 代码会进入 ``_build_execute_method``。
+
+QECGate 参数结构
+----------------
+
+``QECGate`` 是 QEC examples mirror 使用的 compiler-only primitive。
+
+.. code-block:: python
+
+   QECGate(reg_list=["q"], param_list=[gate_name, qubits, params])
+
+例如：
+
+.. code-block:: python
+
+   QECGate(reg_list=["q"], param_list=["RZ", [2], [0.125]])
+
+会发出：
+
+.. code-block:: python
+
+   AbstractGate(name="RZ", qubits=(2,), params=(0.125,))
+
+它没有 PySparQ reference，也没有 pyqres resource estimator 语义。

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -1,36 +1,59 @@
 安装
 ====
 
-系统要求
---------
-
-- Python 3.10+
-- pip 包管理器
-
-从源码安装
+单项目安装
 ----------
 
 .. code-block:: bash
 
-   git clone https://github.com/Agony5757/Quantum-Resource-Estimator.git
+   git clone https://github.com/IAI-USTC-Quantum/Quantum-Resource-Estimator.git
    cd Quantum-Resource-Estimator
-   pip install -e .
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -e ".[test]"
 
-开发安装
---------
+``pysparq`` 是 pyqres 的依赖，用于 ``SimulatorVisitor``。如果需要运行 QEC integration，
+还需要让 ``qec_compiler`` 可导入。
 
-如需运行测试或开发：
+三项目联合安装
+--------------
+
+推荐目录结构：
+
+.. code-block:: text
+
+   connect-pysparq-pyqres-qecc/
+      Quantum-Resource-Estimator/
+      QRAM-Simulator/
+      QEC-compiler/
+
+QEC-Compiler 使用 ``uv``：
 
 .. code-block:: bash
 
-   pip install -e ".[test,dev]"
+   cd QEC-compiler
+   uv venv
+   source .venv/bin/activate
+   uv sync --all-extras
+
+pyqres 调用本地 QEC-Compiler 源码：
+
+.. code-block:: bash
+
+   cd Quantum-Resource-Estimator
+   PYTHONPATH=../QEC-compiler/src:. .venv/bin/python your_script.py
 
 验证安装
 --------
 
-.. code-block:: python
+.. code-block:: bash
 
-   import pyqres
-   # 导出核心类
-   from pyqres import Operation, Primitive, Composite
-   from pyqres import TCounter, TDepthCounter
+   cd Quantum-Resource-Estimator
+   .venv/bin/pyqres compile
+   .venv/bin/pyqres check
+
+   PYTHONPATH=../QEC-compiler/src:. .venv/bin/pytest \
+     tests/test_qec_examples_yaml.py \
+     tests/test_qec_lowering.py \
+     tests/test_intermediate_semantics.py \
+     tests/test_qram_unimplemented.py -q

--- a/docs/source/getting_started/quickstart.rst
+++ b/docs/source/getting_started/quickstart.rst
@@ -1,68 +1,99 @@
 快速入门
 ========
 
+Quantum-Resource-Estimator 采用 register-level Operation tree。一个量子程序既可以用于
+PySparQ simulation，也可以 lowering 到 QEC-Compiler ``AbstractCircuit``。
+
 基本概念
 --------
 
-Quantum-Resource-Estimator 采用 **寄存器级编程范式**，将量子程序表示为操作树。
+* **RegisterMetadata**：声明寄存器名、宽度和类型。
+* **Operation**：量子操作节点，分为 ``Primitive`` 和 ``Composite``。
+* **Visitor**：遍历 Operation tree，用于 simulation、resource counting、QEC lowering。
+* **YAML DSL**：声明 composite operation，并生成 Python 类。
 
-- **寄存器 (Register)**：量子比特的集合，可编码整数、布尔值等
-- **操作 (Operation)**：对寄存器执行的量子门或复合子程序
-- **遍历 (Traverse)**：通过 Visitor 模式遍历操作树进行资源估计
+第一个 simulation 例子
+---------------------
 
-第一个例子
+.. code-block:: python
+
+   import pysparq as ps
+
+   from pyqres.core.metadata import RegisterMetadata
+   from pyqres.core.simulator import SimulatorVisitor
+   from pyqres.primitives import Hadamard, X
+
+   rm = RegisterMetadata.get_register_metadata()
+   rm.declare_register("q", 2, "UnsignedInteger")
+
+   sim = SimulatorVisitor()
+   Hadamard(["q"]).traverse(sim)
+   X(["q"], [0]).traverse(sim)
+
+   print(ps.StatePrint(sim.state, ps.StatePrintDisplay.Detail))
+
+第一个 QEC lowering 例子
+------------------------
+
+.. code-block:: python
+
+   from pyqres.core.lowering import to_abstract_circuit
+   from pyqres.core.metadata import RegisterMetadata
+   from pyqres.primitives import Hadamard, CNOT
+
+   rm = RegisterMetadata.get_register_metadata()
+   rm.declare_register("q0", 1, "Boolean")
+   rm.declare_register("q1", 1, "Boolean")
+
+   class BellProgram:
+       def __init__(self):
+           self.program_list = [Hadamard(["q0"]), CNOT(["q0", "q1"], [0, 0])]
+
+       def traverse(self, visitor, dagger_ctx=False, controllers_ctx=None):
+           for op in self.program_list:
+               op.traverse(visitor, dagger_ctx, controllers_ctx or {})
+
+   circuit = to_abstract_circuit(BellProgram())
+   print(circuit.num_qubits)                # 2
+   print([gate.name for gate in circuit.gates])  # ['H', 'CNOT']
+
+使用 YAML generated operation
+-----------------------------
+
+.. code-block:: bash
+
+   pyqres compile
+
+.. code-block:: python
+
+   from pyqres.core.lowering import to_abstract_circuit
+   from pyqres.core.metadata import RegisterMetadata
+   from pyqres.generated import QECExampleGHZ
+
+   RegisterMetadata.get_register_metadata().declare_register("q", 4, "General")
+   op = QECExampleGHZ(["q"], [4])
+   circuit = to_abstract_circuit(op)
+
+   assert [gate.name for gate in circuit.gates] == ["H", "CNOT", "CNOT", "CNOT"]
+
+进入 QEC-Compiler
+-----------------
+
+.. code-block:: python
+
+   from qec_compiler import QECCompiler
+
+   compilation = QECCompiler().compile(
+       circuit,
+       data_block_style="intermediate",
+       distance_data=3,
+       distance_factory=3,
+   )
+   print(compilation.operation_schedule.total_cycles)
+
+下一步阅读
 ----------
 
-计算 Hadamard 门的 T-count：
-
-.. code-block:: python
-
-   from pyqres import Hadamard, TCounter
-   from pyqres.core.metadata import RegisterMetadata
-
-   # 声明寄存器
-   RegisterMetadata.declare_register('q', 1)
-
-   # 创建操作
-   h = Hadamard(['q'])
-
-   # 计算 T-count
-   counter = TCounter()
-   h.traverse(counter)
-   print(f"T-count: {counter.get_result()}")  # T-count: 0
-
-创建组合操作
-------------
-
-组合多个基本门形成复杂操作：
-
-.. code-block:: python
-
-   from pyqres import CNOT, Swap_General_General
-
-   # 声明寄存器
-   RegisterMetadata.declare_register('q1', 1)
-   RegisterMetadata.declare_register('q2', 1)
-
-   # Swap 操作（由 3 个 CNOT 组成）
-   swap = Swap_General_General(['q1', 'q2'])
-
-   # 计算 T-count
-   counter = TCounter()
-   swap.traverse(counter)
-   print(f"T-count: {counter.get_result()}")
-
-使用控制操作
-------------
-
-为操作添加控制条件：
-
-.. code-block:: python
-
-   # 受控 CNOT
-   cnot_controlled = CNOT(['q1', 'q2']).control('q3')
-
-   # 计算 T-count（受控 CNOT 有 T 门开销）
-   counter = TCounter()
-   cnot_controlled.traverse(counter)
-   print(f"T-count: {counter.get_result()}")
+* :doc:`../workflow/index`：完整三项目工作流。
+* :doc:`../defining_operations/yaml_dsl`：YAML DSL 示例。
+* :doc:`../api/qec_intermediate_contract`：pyqres/QEC-Compiler 中间层 primitive contract。

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,17 +1,32 @@
-.. Quantum-Resource-Estimator documentation master file
-
 Quantum-Resource-Estimator (pyqres) 文档
 ========================================
 
-Quantum-Resource-Estimator 是一个基于 Python 的量子计算资源估计工具，采用 **寄存器级编程范式**，
-估算 T-count、T-depth、Toffoli-count、Toffoli-depth，
-对接 PySparQ C++ 模拟器，支持 Quantikz LaTeX 线路图生成。
+Quantum-Resource-Estimator 是一个 register-level 量子算法编程、模拟、资源估计和
+QEC 编译对接工具。当前主线是把 pyqres 作为算法 authoring layer：算法先写成 YAML DSL
+或 Python ``Operation`` tree，再用 PySparQ 做小规模语义验证，最后 lowering 到
+QEC-Compiler ``AbstractCircuit``，进入 QEC-level schedule/QEOL 资源计算。
+
+核心链路：
+
+.. code-block:: text
+
+   YAML DSL / Python Operation tree
+      -> PySparQ simulation when supported
+      -> pyqres QEC lowering
+      -> QEC-Compiler AbstractCircuit
+      -> logical lowering / lattice surgery / QEOL
 
 .. toctree::
    :maxdepth: 2
    :caption: 快速开始
 
    getting_started/index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: 联合工作流
+
+   workflow/index
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/workflow/full_pipeline.rst
+++ b/docs/source/workflow/full_pipeline.rst
@@ -1,0 +1,96 @@
+完整调用链路
+============
+
+本页给出从 pyqres 程序到 QEC-Compiler ``AbstractCircuit`` 的最小可复用模式。
+
+声明寄存器
+----------
+
+pyqres lowering 和 simulation 都依赖 ``RegisterMetadata``：
+
+.. code-block:: python
+
+   from pyqres.core.metadata import RegisterMetadata
+
+   rm = RegisterMetadata.get_register_metadata()
+   rm.declare_register("q0", 1, "Boolean")
+   rm.declare_register("q1", 1, "Boolean")
+
+构造 Operation tree
+-------------------
+
+.. code-block:: python
+
+   from pyqres.primitives import Hadamard, CNOT
+
+   class BellProgram:
+       def __init__(self):
+           self.program_list = [
+               Hadamard(["q0"]),
+               CNOT(["q0", "q1"], [0, 0]),
+           ]
+
+       def traverse(self, visitor, dagger_ctx=False, controllers_ctx=None):
+           for op in self.program_list:
+               op.traverse(visitor, dagger_ctx, controllers_ctx or {})
+
+   program = BellProgram()
+
+PySparQ simulation smoke
+------------------------
+
+.. code-block:: python
+
+   import pysparq as ps
+   from pyqres.core.simulator import SimulatorVisitor
+
+   sim = SimulatorVisitor()
+   program.traverse(sim)
+   print(ps.StatePrint(sim.state, ps.StatePrintDisplay.Detail))
+
+lower 到 AbstractCircuit
+------------------------
+
+.. code-block:: python
+
+   from pyqres.core.lowering import to_abstract_circuit
+   from qec_compiler.ir import emit_ir_json
+
+   circuit = to_abstract_circuit(program)
+   print(circuit.num_qubits)
+   print([gate.name for gate in circuit.gates])
+   open("circuit.ir.json", "w", encoding="utf-8").write(emit_ir_json(circuit))
+
+进入 QEC-Compiler
+-----------------
+
+.. code-block:: python
+
+   from qec_compiler import QECCompiler
+   from qec_compiler.output import emit_qeol_json
+
+   compilation = QECCompiler().compile(
+       circuit,
+       data_block_style="intermediate",
+       distance_data=3,
+       distance_factory=3,
+   )
+   open("qeol.json", "w", encoding="utf-8").write(
+       emit_qeol_json(compilation.qeol_program)
+   )
+
+也可以通过 CLI 编译：
+
+.. code-block:: bash
+
+   cd QEC-compiler
+   MPLCONFIGDIR=/tmp .venv/bin/qec-compile \
+     ../Quantum-Resource-Estimator/circuit.ir.json \
+     --style intermediate \
+     --d 3 \
+     --d-fac 3 \
+     --out-dir runs/pyqres_demo
+
+输出目录包含 ``logical_circuit.ir.json``、``surgery_graph.ir.json``、
+``layout_plan.ir.json``、``operation_schedule.ir.json``、``space_time_schedule.ir.json``、
+``qeol.json`` 等 QEC artifacts。

--- a/docs/source/workflow/index.rst
+++ b/docs/source/workflow/index.rst
@@ -1,0 +1,17 @@
+pyqres -> PySparQ -> QEC-Compiler 联合工作流
+=============================================
+
+本章是 Quantum-Resource-Estimator 当前最重要的使用路径：以 pyqres YAML DSL
+和 Operation tree 作为算法入口，先在 PySparQ 中做 register-level 语义验证，
+再 lowering 到 QEC-Compiler 的 ``AbstractCircuit``，最终进入 QEC 编译和资源计算。
+
+.. toctree::
+   :maxdepth: 1
+
+   philosophy
+   installation
+   full_pipeline
+   supported_algorithms
+   yaml_qec_examples
+   qda_tridiagonal
+   qram_status

--- a/docs/source/workflow/installation.rst
+++ b/docs/source/workflow/installation.rst
@@ -1,0 +1,88 @@
+三项目源码安装
+==============
+
+推荐在同一父目录下并列放置三个项目：
+
+.. code-block:: text
+
+   connect-pysparq-pyqres-qecc/
+      Quantum-Resource-Estimator/
+      QRAM-Simulator/
+      QEC-compiler/
+
+安装 PySparQ
+------------
+
+PySparQ 来自 QRAM-Simulator，是 pyqres simulation visitor 的运行时依赖。
+
+.. code-block:: bash
+
+   cd QRAM-Simulator
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -e .
+
+如果需要构建 C++ 测试：
+
+.. code-block:: bash
+
+   cd QRAM-Simulator
+   mkdir -p build
+   cd build
+   cmake .. -DCMAKE_BUILD_TYPE=Release
+   make -j$(nproc)
+   ctest --output-on-failure
+
+当前 GPU/CUDA 后端不是 pyqres/QEC 联调主线，默认按 CPU-only 使用。
+
+安装 QEC-Compiler
+-----------------
+
+QEC-Compiler 使用 ``uv`` 管理开发环境：
+
+.. code-block:: bash
+
+   cd QEC-compiler
+   uv venv
+   source .venv/bin/activate
+   uv sync --all-extras
+   uv run qec-compile --version
+
+安装 pyqres
+------------
+
+.. code-block:: bash
+
+   cd Quantum-Resource-Estimator
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -e ".[test]"
+
+跨项目导入 QEC-Compiler
+-----------------------
+
+如果 QEC-Compiler 没有安装成 site-package，可在运行 pyqres QEC 测试或脚本时指定：
+
+.. code-block:: bash
+
+   cd Quantum-Resource-Estimator
+   PYTHONPATH=../QEC-compiler/src:. .venv/bin/python your_script.py
+
+常用联调命令
+------------
+
+.. code-block:: bash
+
+   cd Quantum-Resource-Estimator
+   .venv/bin/pyqres compile
+   .venv/bin/pyqres check
+   PYTHONPATH=../QEC-compiler/src:. .venv/bin/pytest \
+     tests/test_qec_examples_yaml.py \
+     tests/test_qec_lowering.py \
+     tests/test_intermediate_semantics.py \
+     tests/test_qram_unimplemented.py -q
+
+   cd ../QEC-compiler
+   .venv/bin/python -m pytest \
+     tests/test_arithmetic_decomposition.py \
+     tests/test_arithmetic_truth_table.py -q

--- a/docs/source/workflow/philosophy.rst
+++ b/docs/source/workflow/philosophy.rst
@@ -1,0 +1,58 @@
+设计哲学：从算法实现到 QEC 资源计算
+====================================
+
+Quantum-Resource-Estimator 当前的定位不是单纯统计 T-count 或 Toffoli-count。
+它是一个量子算法 authoring layer，目标是把算法程序逐步推进到 QEC 编译器：
+
+.. code-block:: text
+
+   pyqres YAML DSL
+      -> generated Python Composite
+      -> pyqres Operation tree
+      -> PySparQ register-level simulation
+      -> pyqres QEC lowering
+      -> QEC-Compiler AbstractCircuit
+      -> logical lowering / layout / schedule
+      -> QEOL JSON and QEC-level resource artifacts
+
+三个项目的职责边界
+------------------
+
+``Quantum-Resource-Estimator`` / ``pyqres``
+    算法入口。负责 YAML DSL、Operation tree、visitor、coarse resource estimator、
+    PySparQ simulation visitor、QEC lowering 和 intermediate primitive contract。
+
+``QRAM-Simulator`` / ``PySparQ``
+    语义虚拟机。负责 register-level sparse-state simulation，用于小规模算法和 primitive
+    的 correctness smoke/reference。PySparQ reference 必须语义等价；没有等价 reference
+    时必须抛 ``NotImplementedError``，不能用近似 primitive 冒充。
+
+``QEC-Compiler``
+    QEC 编译器。接收 ``AbstractCircuit``，执行 arithmetic/MCX/CCZ/Pauli-product lowering、
+    lattice-surgery layout、schedule 和 QEOL 输出。
+
+工程原则
+--------
+
+* pyqres 程序保持 register-level 结构，不强迫用户手写底层门序列。
+* QEC lowering 必须 fail closed：未知 primitive 抛 ``UnsupportedQECPrimitive``。
+* controlled/dagger 语义必须显式进入 QEC gate name 或显式拒绝。
+* modular arithmetic 只在声明的 valid subspace 上保证语义。
+* QEC 资源计算不是“估一个数字”，而是生成可检查的 IR、schedule、QEOL artifacts。
+
+当前阶段判定
+------------
+
+已经稳定的闭环是：
+
+* YAML DSL 可以生成 Python ``Composite``。
+* pyqres 可以生成 QEC-Compiler ``AbstractCircuit``。
+* QEC examples 的 gate-level YAML mirrors 可以逐门匹配 QEC-Compiler builders。
+* QDA-tridiagonal 可以在多个矩阵尺寸下自动 lowering 到 ``AbstractCircuit``。
+* ``MOD_ADD``/``MOD_MUL`` 等第一批 intermediate primitive 可以进入 QEC arithmetic lowering。
+
+尚未宣称完成的是：
+
+* QRAM 的 pyqres wrapper 语义。
+* 所有高层算法的完整 statevector 对拍。
+* 大规模优化级 arithmetic implementation。

--- a/docs/source/workflow/qda_tridiagonal.rst
+++ b/docs/source/workflow/qda_tridiagonal.rst
@@ -1,0 +1,97 @@
+QDA-tridiagonal 工作流
+======================
+
+QDA-tridiagonal 是当前 pyqres 中最重要的 register-level 算法工作流之一。
+它不使用 QRAM，而是通过 ``BlockEncodingTridiagonal`` 编码三对角矩阵。
+
+组件
+----
+
+``BlockEncodingTridiagonal``
+    手写 Python composite，位于 ``pyqres.algorithms.block_encoding``。
+    它使用 ``SplitRegister``、``Rot_GeneralStatePrep``、``PlusOneOverflow``、
+    ``Reflection_Bool`` 等 primitive 构造三对角矩阵 block encoding。
+
+``WalkS_Primitive``
+    手写 QDA walk operator，位于 ``pyqres.algorithms.qda_solver``。
+
+``QDALinearSolver``
+    YAML 生成的 composite，位于 ``pyqres.generated``。
+    它接收 ``encode_A`` / ``encode_b`` operation 参数，并在 adiabatic steps 中调用 ``WalkS_Primitive``。
+
+最小 QEC lowering 示例
+----------------------
+
+.. code-block:: python
+
+   from pyqres.algorithms.block_encoding import BlockEncodingTridiagonal
+   from pyqres.core.lowering import to_abstract_circuit
+   from pyqres.core.metadata import RegisterMetadata
+   from pyqres.generated import QDALinearSolver
+
+   rm = RegisterMetadata.get_register_metadata()
+   rm.declare_register("main", 2, "UnsignedInteger")
+   rm.declare_register("anc_UA", 4, "UnsignedInteger")
+   rm.declare_register("anc_1", 1, "Boolean")
+   rm.declare_register("anc_2", 1, "Boolean")
+   rm.declare_register("anc_3", 1, "Boolean")
+   rm.declare_register("anc_4", 1, "Boolean")
+
+   def make_enc_A(reg_list=None, param_list=None):
+       return BlockEncodingTridiagonal(
+           reg_list=reg_list,
+           main_reg=reg_list[0],
+           anc_UA=reg_list[1],
+           alpha=0.5,
+           beta=0.3,
+       )
+
+   op = QDALinearSolver(
+       reg_list=["main", "anc_UA", "anc_1", "anc_2", "anc_3", "anc_4"],
+       param_list=[2.0, 1.0],
+       operations=[make_enc_A],
+   )
+   circuit = to_abstract_circuit(op)
+
+矩阵尺寸
+--------
+
+``main`` register 的 bit 数决定矩阵维度：
+
+.. list-table::
+   :widths: 20 20 60
+   :header-rows: 1
+
+   * - ``main_bits``
+     - 矩阵维度
+     - 当前测试状态
+   * - 1
+     - 2 x 2
+     - 可自动 lowering 到 ``AbstractCircuit`` 并进入 ``lower_to_logical``。
+   * - 2
+     - 4 x 4
+     - 可自动 lowering 到 ``AbstractCircuit`` 并进入 ``lower_to_logical``。
+   * - 3
+     - 8 x 8
+     - 可自动 lowering 到 ``AbstractCircuit`` 并进入 ``lower_to_logical``。
+
+验证命令
+--------
+
+.. code-block:: bash
+
+   PYTHONPATH=../QEC-compiler/src:. .venv/bin/pytest \
+     tests/test_qec_lowering.py -q
+
+相关测试包括：
+
+* ``test_walks_with_tridiagonal_compiles``
+* ``test_generated_qda_tridiagonal_lowers_for_matrix_sizes``
+* ``test_block_encoding_tridiagonal_produces_gates``
+
+注意事项
+--------
+
+* 当前 QDA-tridiagonal 测试是 compile/lowering smoke，不等价于完整 QDA 数值正确性证明。
+* ``encode_b`` 如果未传入，会走 ``WalkS_Primitive`` 的 Hadamard fallback。
+* QRAM-based QDA 当前不属于支持路径。

--- a/docs/source/workflow/qram_status.rst
+++ b/docs/source/workflow/qram_status.rst
@@ -1,0 +1,56 @@
+QRAM 当前策略
+=============
+
+当前 pyqres/QEC 联调主线明确暂不支持 QRAM wrapper。
+
+实际行为
+--------
+
+``pyqres.primitives.QRAM`` 和 ``pyqres.primitives.QRAMFast`` 仍保留类名，保证历史 YAML/Python import 不崩溃；但它们的语义入口全部显式报错：
+
+.. code-block:: text
+
+   QRAM.pyqsparse_object()      -> NotImplementedError
+   QRAM.t_count()               -> NotImplementedError
+   QRAMFast.pyqsparse_object()  -> NotImplementedError
+   QRAMFast.t_count()           -> NotImplementedError
+
+为什么不能用 dummy memory
+-------------------------
+
+QRAM 是强语义 primitive：address/data width、memory layout、load/unload 是否 self-adjoint、
+clean ancilla contract、QEC lowering 资源模型都必须明确。用 dummy memory 或普通 arithmetic primitive
+冒充会让 PySparQ reference 与 QEC contract 不一致。
+
+因此当前策略是 fail closed：
+
+* 不提供近似 PySparQ reference。
+* 不提供 T-count 占位数。
+* 不进入 QEC lowering 主路径。
+
+测试记录
+--------
+
+.. code-block:: bash
+
+   .venv/bin/pytest tests/test_qram_unimplemented.py -q
+
+测试使用 strict ``xfail``，表示当前预期行为就是 ``NotImplementedError``。未来 QRAM contract 修复后，应删除 xfail 并补充正向 reference tests。
+
+直接 PySparQ QRAM
+-----------------
+
+如果只是实验 QRAM-Simulator 本体，可以直接使用 PySparQ API；这不代表 pyqres QRAM wrapper 已经进入稳定 workflow。
+
+.. code-block:: python
+
+   import pysparq as ps
+
+   ps.System.clear()
+   state = ps.SparseState()
+   ps.AddRegister("addr", ps.UnsignedInteger, 2)(state)
+   ps.AddRegister("data", ps.UnsignedInteger, 3)(state)
+   ps.Hadamard_Int("addr", 2)(state)
+
+   qram = ps.QRAMCircuit_qutrit(2, 3, [0, 2, 4, 6])
+   ps.QRAMLoad(qram, "addr", "data")(state)

--- a/docs/source/workflow/supported_algorithms.rst
+++ b/docs/source/workflow/supported_algorithms.rst
@@ -1,0 +1,81 @@
+支持的量子算法与当前状态
+========================
+
+pyqres 中算法分为三类：
+
+* YAML DSL 定义并生成到 ``pyqres.generated`` 的 composite。
+* ``pyqres.algorithms`` 中手写的复杂算法模块。
+* 为 QEC-Compiler examples 做 gate-level parity 的 YAML mirror。
+
+当前支持矩阵
+------------
+
+.. list-table::
+   :widths: 24 24 24 28
+   :header-rows: 1
+
+   * - 算法/家族
+     - pyqres 表达方式
+     - QEC AbstractCircuit
+     - 说明
+   * - GHZ / W state
+     - YAML mirror ``QECExampleGHZ`` / ``QECExampleW``
+     - 已逐门匹配 QEC-Compiler builder
+     - 用于 state-prep benchmark parity。
+   * - Bernstein-Vazirani
+     - YAML mirror ``QECExampleBV``
+     - 已逐门匹配
+     - 覆盖 oracle CNOT 结构。
+   * - Deutsch-Jozsa
+     - YAML mirror ``QECExampleDJ``
+     - 已逐门匹配
+     - 覆盖 balanced/constant oracle gate pattern。
+   * - Grover
+     - YAML mirror ``QECExampleGrover`` 和已有 ``GroverSearch``
+     - mirror 已逐门匹配
+     - ``GroverSearch`` 是更高层 DSL 算法；mirror 用于 QEC examples parity。
+   * - QFT / QPE
+     - YAML mirror ``QECExampleQFT`` / ``QECExampleQPE``
+     - 已逐门匹配
+     - 覆盖 ``H``、``CPHASE``、``SWAP``。
+   * - QAOA / VQE / Ising
+     - YAML mirror
+     - 已逐门匹配
+     - 覆盖 rotation-heavy benchmark。
+   * - SWAP-test
+     - YAML mirror ``QECExampleSwapTest``
+     - 已逐门匹配
+     - 覆盖 Fredkin/CCX-style 结构。
+   * - small Shor fixture
+     - YAML mirror ``QECExampleSmallShor`` 和 hand-written Shor
+     - 已逐门匹配 QEC fixture；pyqres Shor 可 lower
+     - ``CMUL_MOD_N`` 是 legacy compatibility gate。
+   * - QDA-tridiagonal
+     - hand-written ``BlockEncodingTridiagonal`` + generated ``QDALinearSolver``
+     - 多尺寸 smoke 已通过
+     - 当前测试覆盖 ``main_bits = 1, 2, 3``。
+   * - QRAM-based algorithms
+     - YAML/hand-written definitions may import QRAM wrappers
+     - 暂不支持
+     - QRAM wrappers 显式抛 ``NotImplementedError``。
+
+为什么有 YAML mirror
+-------------------
+
+QEC-Compiler 的 curated examples 原本直接构造 ``AbstractCircuit``。为了验证
+“pyqres YAML DSL -> generated Python -> AbstractCircuit”这一步，pyqres 提供一组
+``QECExample*`` YAML mirror。它们通过 compiler-only ``QECGate`` adapter 发出与
+QEC-Compiler builder 完全相同的 gate name、qubit order 和 params。
+
+这条路径的目的很明确：
+
+* 证明 YAML DSL 可以承载 QEC examples 的 gate-level 工作流。
+* 避免把 measurement/metadata 和 PySparQ reference 混在一起。
+* 为后续把 gate-level mirror 逐步提升为 register-level algorithm 提供回归基线。
+
+限制
+----
+
+* 当前 parity 测试比较 ``num_qubits``、``gates``、``qubits``、``params``。
+* pyqres QEC lowering 目前不表达 QEC-Compiler examples 的 measurements 和 metadata。
+* ``QECGate`` 没有 PySparQ reference，也不提供 pyqres T-count；它只用于编译器 parity。

--- a/docs/source/workflow/yaml_qec_examples.rst
+++ b/docs/source/workflow/yaml_qec_examples.rst
@@ -1,0 +1,176 @@
+YAML 定义 QEC-Compiler examples
+===============================
+
+入口文件
+--------
+
+QEC examples 的 YAML mirror 定义在：
+
+.. code-block:: text
+
+   pyqres/dsl/schemas/composites/qec_examples.yml
+
+编译后生成：
+
+.. code-block:: text
+
+   pyqres/generated/QECExampleGHZ.py
+   pyqres/generated/QECExampleW.py
+   pyqres/generated/QECExampleBV.py
+   ...
+
+运行编译：
+
+.. code-block:: bash
+
+   cd Quantum-Resource-Estimator
+   .venv/bin/pyqres compile
+   .venv/bin/pyqres check
+
+核心机制：QECGate
+-----------------
+
+``QECGate`` 是 compiler-only adapter。YAML helper 使用它直接发出 QEC-Compiler
+``AbstractGate``：
+
+.. code-block:: python
+
+   QECGate(
+       reg_list=["q"],
+       param_list=["CNOT", [0, 1], []],
+   )
+
+含义是：在寄存器 ``q`` 的 bit 0 和 bit 1 上发出 QEC gate ``CNOT``。
+
+``QECGate`` 的约束：
+
+* 只用于 ``AbstractCircuit`` emission。
+* ``pyqsparse_object()`` 抛 ``NotImplementedError``。
+* ``t_count()`` 抛 ``NotImplementedError``。
+* 不代表 register-level algorithm primitive。
+
+示例：GHZ
+---------
+
+.. code-block:: yaml
+
+   - name: QECExampleGHZ
+     description: "YAML mirror of QEC-Compiler GHZ benchmark gates"
+     qregs:
+       - {name: q, type: General}
+     params:
+       - {name: n, type: int}
+     impl:
+       - python: |
+           from ..algorithms.qec_examples import build_qec_ghz
+       - python: |
+           build_qec_ghz(self.program_list, self.q, self.n)
+
+使用：
+
+.. code-block:: python
+
+   from pyqres.core.metadata import RegisterMetadata
+   from pyqres.core.lowering import to_abstract_circuit
+   from pyqres.generated import QECExampleGHZ
+
+   RegisterMetadata.get_register_metadata().declare_register("q", 4, "General")
+   op = QECExampleGHZ(["q"], [4])
+   circuit = to_abstract_circuit(op)
+
+   assert [gate.name for gate in circuit.gates] == ["H", "CNOT", "CNOT", "CNOT"]
+
+示例：QFT
+---------
+
+.. code-block:: yaml
+
+   - name: QECExampleQFT
+     qregs:
+       - {name: q, type: General}
+     params:
+       - {name: n, type: int}
+     impl:
+       - python: |
+           from ..algorithms.qec_examples import build_qec_qft
+       - python: |
+           build_qec_qft(self.program_list, self.q, self.n)
+
+Python 使用：
+
+.. code-block:: python
+
+   from pyqres.generated import QECExampleQFT
+
+   RegisterMetadata.get_register_metadata().declare_register("q", 4, "General")
+   qft = QECExampleQFT(["q"], [4])
+   circuit = to_abstract_circuit(qft)
+
+QEC-Compiler builder parity 测试逐门比较 ``H``、``CPHASE``、``SWAP`` 的顺序、参数和 qubit order。
+
+示例：QAOA
+----------
+
+.. code-block:: yaml
+
+   - name: QECExampleQAOA
+     qregs:
+       - {name: q, type: General}
+     params:
+       - {name: n_vertices, type: int}
+       - {name: edges, type: array}
+       - {name: p, type: int}
+       - {name: gamma, type: float}
+       - {name: beta, type: float}
+     impl:
+       - python: |
+           from ..algorithms.qec_examples import build_qec_qaoa
+       - python: |
+           build_qec_qaoa(
+               self.program_list, self.q, self.n_vertices, self.edges,
+               self.p, self.gamma, self.beta)
+
+Python 使用：
+
+.. code-block:: python
+
+   import math
+   from pyqres.generated import QECExampleQAOA
+
+   edges = [(0, 1), (1, 2), (2, 3)]
+   RegisterMetadata.get_register_metadata().declare_register("q", 4, "General")
+   op = QECExampleQAOA(["q"], [4, edges, 1, math.pi / 4, math.pi / 8])
+   circuit = to_abstract_circuit(op)
+
+示例：small Shor fixture
+-----------------------
+
+.. code-block:: yaml
+
+   - name: QECExampleSmallShor
+     qregs:
+       - {name: q, type: General}
+     params:
+       - {name: modulus, type: int}
+       - {name: base, type: int}
+     impl:
+       - python: |
+           from ..algorithms.qec_examples import build_qec_small_shor
+       - python: |
+           build_qec_small_shor(self.program_list, self.q, self.modulus, self.base)
+
+当前支持 ``N=15`` 和 ``N=21``，与 QEC-Compiler stage-5 small Shor fixture 对齐。
+
+验证命令
+--------
+
+.. code-block:: bash
+
+   PYTHONPATH=../QEC-compiler/src:. .venv/bin/pytest \
+     tests/test_qec_examples_yaml.py -q
+
+该测试覆盖：
+
+.. code-block:: text
+
+   GHZ, W, BV, DJ, Grover, QFT, QPE, QAOA, VQE, Ising, SWAP-test, small Shor

--- a/pyqres/algorithms/qec_examples.py
+++ b/pyqres/algorithms/qec_examples.py
@@ -1,0 +1,239 @@
+"""Helpers for YAML-defined mirrors of QEC-Compiler benchmark examples.
+
+The public definitions live in ``pyqres/dsl/schemas/composites/qec_examples.yml``.
+These helpers keep generated YAML classes small while preserving exact
+gate-level parity with QEC-Compiler's benchmark builders.
+"""
+
+from __future__ import annotations
+
+import math
+from math import gcd
+
+from ..core.registry import OperationRegistry
+
+
+def append_qec_gate(program_list, qreg: str, name: str, qubits, params=()) -> None:
+    gate_cls = OperationRegistry.get_class("QECGate")
+    program_list.append(
+        gate_cls(reg_list=[qreg], param_list=[name, list(qubits), list(params)])
+    )
+
+
+def build_qec_ghz(program_list, qreg: str, n: int) -> None:
+    append_qec_gate(program_list, qreg, "H", (0,))
+    for i in range(n - 1):
+        append_qec_gate(program_list, qreg, "CNOT", (i, i + 1))
+
+
+def build_qec_w(program_list, qreg: str, n: int) -> None:
+    def rec(i: int) -> None:
+        if i == n - 1:
+            append_qec_gate(program_list, qreg, "X", (i,))
+            return
+        theta = 2 * math.asin(math.sqrt((n - i - 1) / (n - i)))
+        append_qec_gate(program_list, qreg, "RY", (i,), (theta,))
+        append_qec_gate(program_list, qreg, "CNOT", (i, i + 1))
+        append_qec_gate(program_list, qreg, "RY", (i + 1,), (-theta,))
+        append_qec_gate(program_list, qreg, "CNOT", (i, i + 1))
+        append_qec_gate(program_list, qreg, "X", (i,))
+        rec(i + 1)
+
+    rec(0)
+
+
+def build_qec_bv(program_list, qreg: str, n: int, secret: int) -> None:
+    for i in range(n):
+        append_qec_gate(program_list, qreg, "H", (i,))
+    for i in range(n):
+        if (secret >> i) & 1:
+            append_qec_gate(program_list, qreg, "CNOT", (i, n))
+    for i in range(n):
+        append_qec_gate(program_list, qreg, "H", (i,))
+
+
+def build_qec_dj(program_list, qreg: str, n: int, balanced: bool) -> None:
+    ancilla = n
+    append_qec_gate(program_list, qreg, "X", (ancilla,))
+    append_qec_gate(program_list, qreg, "H", (ancilla,))
+    for i in range(n):
+        append_qec_gate(program_list, qreg, "H", (i,))
+    if balanced:
+        for i in range(n):
+            append_qec_gate(program_list, qreg, "CNOT", (i, ancilla))
+    for i in range(n):
+        append_qec_gate(program_list, qreg, "H", (i,))
+
+
+def build_qec_grover(program_list, qreg: str, n: int, marked_states, iterations: int) -> None:
+    for i in range(n):
+        append_qec_gate(program_list, qreg, "H", (i,))
+    for _ in range(iterations):
+        for target in marked_states:
+            for i in range(n):
+                if (int(target) >> i) & 1:
+                    append_qec_gate(program_list, qreg, "X", (i,))
+        for i in range(n - 1):
+            append_qec_gate(program_list, qreg, "CNOT", (i, i + 1))
+        append_qec_gate(program_list, qreg, "X", (n - 1,))
+        for i in range(n):
+            append_qec_gate(program_list, qreg, "X", (i,))
+        for i in range(n):
+            append_qec_gate(program_list, qreg, "H", (i,))
+
+
+def build_qec_qft(program_list, qreg: str, n: int) -> None:
+    for i in range(n):
+        append_qec_gate(program_list, qreg, "H", (i,))
+        for j in range(i + 1, n):
+            theta = math.pi / (1 << (j - i))
+            append_qec_gate(program_list, qreg, "CPHASE", (i, j), (theta,))
+    for i in range(n // 2):
+        append_qec_gate(program_list, qreg, "SWAP", (i, n - 1 - i))
+
+
+def _append_iqft(program_list, qreg: str, n: int) -> None:
+    for i in range(n // 2):
+        append_qec_gate(program_list, qreg, "SWAP", (i, n - 1 - i))
+    for i in reversed(range(n)):
+        for j in reversed(range(i + 1, n)):
+            theta = -math.pi / (1 << (j - i))
+            append_qec_gate(program_list, qreg, "CPHASE", (i, j), (theta,))
+        append_qec_gate(program_list, qreg, "H", (i,))
+
+
+def build_qec_qpe(
+    program_list,
+    qreg: str,
+    n_counting: int,
+    n_system: int,
+    unitary_eigenvalue: float,
+) -> None:
+    for i in range(n_counting):
+        append_qec_gate(program_list, qreg, "H", (i,))
+    phase = 2 * math.pi * unitary_eigenvalue
+    for i in range(n_counting):
+        theta = phase * (1 << i)
+        for s in range(n_system):
+            append_qec_gate(program_list, qreg, "CPHASE", (i, n_counting + s), (theta,))
+    _append_iqft(program_list, qreg, n_counting)
+
+
+def build_qec_qaoa(
+    program_list,
+    qreg: str,
+    n_vertices: int,
+    edges,
+    p: int,
+    gamma: float,
+    beta: float,
+) -> None:
+    for i in range(n_vertices):
+        append_qec_gate(program_list, qreg, "H", (i,))
+    for _layer in range(p):
+        g = gamma / p
+        b = beta / p
+        for u, v in edges:
+            append_qec_gate(program_list, qreg, "CNOT", (u, v))
+            append_qec_gate(program_list, qreg, "RZ", (v,), (g,))
+            append_qec_gate(program_list, qreg, "CNOT", (u, v))
+        for i in range(n_vertices):
+            append_qec_gate(program_list, qreg, "RX", (i,), (b,))
+
+
+def build_qec_vqe(
+    program_list,
+    qreg: str,
+    n_qubits: int,
+    layers: int,
+    ring_entanglement: bool,
+) -> None:
+    for layer in range(layers):
+        scale = layer + 1
+        for qubit in range(n_qubits):
+            theta_y = math.pi * scale * (qubit + 1) / (2 * (n_qubits + layers))
+            theta_z = math.pi * scale * (qubit + 2) / (4 * (n_qubits + layers))
+            append_qec_gate(program_list, qreg, "RY", (qubit,), (theta_y,))
+            append_qec_gate(program_list, qreg, "RZ", (qubit,), (theta_z,))
+        for control in range(n_qubits - 1):
+            append_qec_gate(program_list, qreg, "CNOT", (control, control + 1))
+        if ring_entanglement and n_qubits > 2:
+            append_qec_gate(program_list, qreg, "CNOT", (n_qubits - 1, 0))
+
+
+def build_qec_ising(
+    program_list,
+    qreg: str,
+    n_spins: int,
+    couplings,
+    p_level: int,
+    h_transverse: float,
+) -> None:
+    dt = 0.1
+    for _ in range(p_level):
+        for i, coupling in enumerate(couplings):
+            append_qec_gate(program_list, qreg, "CNOT", (i, i + 1))
+            append_qec_gate(program_list, qreg, "RZ", (i + 1,), (-float(coupling) * dt,))
+            append_qec_gate(program_list, qreg, "CNOT", (i, i + 1))
+        for i in range(n_spins):
+            append_qec_gate(program_list, qreg, "RX", (i,), (-h_transverse * dt,))
+
+
+def build_qec_swap_test(program_list, qreg: str, total_qubits: int) -> None:
+    n_data = (total_qubits - 1) // 2
+    ancilla = 0
+    left_register = tuple(range(1, 1 + n_data))
+    right_register = tuple(range(1 + n_data, total_qubits))
+    append_qec_gate(program_list, qreg, "H", (ancilla,))
+    for offset, qubit in enumerate(left_register):
+        angle = math.pi * (offset + 1) / (2 * (n_data + 1))
+        append_qec_gate(program_list, qreg, "RY", (qubit,), (angle,))
+    for offset, qubit in enumerate(right_register):
+        angle = math.pi * (offset + 2) / (3 * (n_data + 1))
+        append_qec_gate(program_list, qreg, "RZ", (qubit,), (angle,))
+        if offset % 2 == 0:
+            append_qec_gate(program_list, qreg, "X", (qubit,))
+    for left, right in zip(left_register, right_register, strict=True):
+        append_qec_gate(program_list, qreg, "CNOT", (right, left))
+        append_qec_gate(program_list, qreg, "CCX", (ancilla, left, right))
+        append_qec_gate(program_list, qreg, "CNOT", (right, left))
+    append_qec_gate(program_list, qreg, "H", (ancilla,))
+
+
+def build_qec_small_shor(program_list, qreg: str, modulus: int, base: int) -> None:
+    if gcd(base, modulus) != 1:
+        raise ValueError("base must be coprime with modulus")
+    if modulus == 15:
+        counting_bits, work_bits = 4, 4
+    elif modulus == 21:
+        counting_bits, work_bits = 6, 5
+    else:
+        raise ValueError("small Shor YAML mirror supports only N=15 and N=21")
+
+    work_register = tuple(range(counting_bits, counting_bits + work_bits))
+    append_qec_gate(program_list, qreg, "X", (work_register[0],))
+    for qubit in range(counting_bits):
+        append_qec_gate(program_list, qreg, "H", (qubit,))
+
+    multiplier = base % modulus
+    for control in range(counting_bits):
+        append_qec_gate(
+            program_list,
+            qreg,
+            "CMUL_MOD_N",
+            (control, *work_register),
+            (float(multiplier), float(modulus)),
+        )
+        multiplier = pow(multiplier, 2, modulus)
+
+    for left, right in zip(
+        range(counting_bits // 2),
+        reversed(range((counting_bits + 1) // 2, counting_bits)),
+        strict=False,
+    ):
+        append_qec_gate(program_list, qreg, "SWAP", (left, right))
+    for target_offset, target in enumerate(range(counting_bits)):
+        for control_offset, control in enumerate(range(target_offset)):
+            angle = -math.pi / (1 << (target_offset - control_offset))
+            append_qec_gate(program_list, qreg, "CPHASE", (control, target), (angle,))
+        append_qec_gate(program_list, qreg, "H", (target,))

--- a/pyqres/dsl/schemas/composites/qec_examples.yml
+++ b/pyqres/dsl/schemas/composites/qec_examples.yml
@@ -1,0 +1,168 @@
+- name: QECExampleGHZ
+  description: "YAML mirror of QEC-Compiler GHZ benchmark gates"
+  qregs:
+    - {name: q, type: General}
+  params:
+    - {name: n, type: int}
+  impl:
+    - python: |
+        from ..algorithms.qec_examples import build_qec_ghz
+    - python: |
+        build_qec_ghz(self.program_list, self.q, self.n)
+
+- name: QECExampleW
+  description: "YAML mirror of QEC-Compiler W-state benchmark gates"
+  qregs:
+    - {name: q, type: General}
+  params:
+    - {name: n, type: int}
+  impl:
+    - python: |
+        from ..algorithms.qec_examples import build_qec_w
+    - python: |
+        build_qec_w(self.program_list, self.q, self.n)
+
+- name: QECExampleBV
+  description: "YAML mirror of QEC-Compiler Bernstein-Vazirani benchmark gates"
+  qregs:
+    - {name: q, type: General}
+  params:
+    - {name: n, type: int}
+    - {name: secret, type: int}
+  impl:
+    - python: |
+        from ..algorithms.qec_examples import build_qec_bv
+    - python: |
+        build_qec_bv(self.program_list, self.q, self.n, self.secret)
+
+- name: QECExampleDJ
+  description: "YAML mirror of QEC-Compiler Deutsch-Jozsa benchmark gates"
+  qregs:
+    - {name: q, type: General}
+  params:
+    - {name: n, type: int}
+    - {name: balanced, type: bool}
+  impl:
+    - python: |
+        from ..algorithms.qec_examples import build_qec_dj
+    - python: |
+        build_qec_dj(self.program_list, self.q, self.n, self.balanced)
+
+- name: QECExampleGrover
+  description: "YAML mirror of QEC-Compiler Grover benchmark gates"
+  qregs:
+    - {name: q, type: General}
+  params:
+    - {name: n, type: int}
+    - {name: marked_states, type: array}
+    - {name: iterations, type: int}
+  impl:
+    - python: |
+        from ..algorithms.qec_examples import build_qec_grover
+    - python: |
+        build_qec_grover(
+            self.program_list, self.q, self.n, self.marked_states, self.iterations)
+
+- name: QECExampleQFT
+  description: "YAML mirror of QEC-Compiler QFT benchmark gates"
+  qregs:
+    - {name: q, type: General}
+  params:
+    - {name: n, type: int}
+  impl:
+    - python: |
+        from ..algorithms.qec_examples import build_qec_qft
+    - python: |
+        build_qec_qft(self.program_list, self.q, self.n)
+
+- name: QECExampleQPE
+  description: "YAML mirror of QEC-Compiler QPE benchmark gates"
+  qregs:
+    - {name: q, type: General}
+  params:
+    - {name: n_counting, type: int}
+    - {name: n_system, type: int}
+    - {name: unitary_eigenvalue, type: float}
+  impl:
+    - python: |
+        from ..algorithms.qec_examples import build_qec_qpe
+    - python: |
+        build_qec_qpe(
+            self.program_list, self.q, self.n_counting,
+            self.n_system, self.unitary_eigenvalue)
+
+- name: QECExampleQAOA
+  description: "YAML mirror of QEC-Compiler QAOA benchmark gates"
+  qregs:
+    - {name: q, type: General}
+  params:
+    - {name: n_vertices, type: int}
+    - {name: edges, type: array}
+    - {name: p, type: int}
+    - {name: gamma, type: float}
+    - {name: beta, type: float}
+  impl:
+    - python: |
+        from ..algorithms.qec_examples import build_qec_qaoa
+    - python: |
+        build_qec_qaoa(
+            self.program_list, self.q, self.n_vertices, self.edges,
+            self.p, self.gamma, self.beta)
+
+- name: QECExampleVQE
+  description: "YAML mirror of QEC-Compiler VQE benchmark gates"
+  qregs:
+    - {name: q, type: General}
+  params:
+    - {name: n_qubits, type: int}
+    - {name: layers, type: int}
+    - {name: ring_entanglement, type: bool}
+  impl:
+    - python: |
+        from ..algorithms.qec_examples import build_qec_vqe
+    - python: |
+        build_qec_vqe(
+            self.program_list, self.q, self.n_qubits,
+            self.layers, self.ring_entanglement)
+
+- name: QECExampleIsing
+  description: "YAML mirror of QEC-Compiler Ising benchmark gates"
+  qregs:
+    - {name: q, type: General}
+  params:
+    - {name: n_spins, type: int}
+    - {name: couplings, type: array}
+    - {name: p_level, type: int}
+    - {name: h_transverse, type: float}
+  impl:
+    - python: |
+        from ..algorithms.qec_examples import build_qec_ising
+    - python: |
+        build_qec_ising(
+            self.program_list, self.q, self.n_spins, self.couplings,
+            self.p_level, self.h_transverse)
+
+- name: QECExampleSwapTest
+  description: "YAML mirror of QEC-Compiler SWAP-test benchmark gates"
+  qregs:
+    - {name: q, type: General}
+  params:
+    - {name: total_qubits, type: int}
+  impl:
+    - python: |
+        from ..algorithms.qec_examples import build_qec_swap_test
+    - python: |
+        build_qec_swap_test(self.program_list, self.q, self.total_qubits)
+
+- name: QECExampleSmallShor
+  description: "YAML mirror of QEC-Compiler small Shor fixture gates"
+  qregs:
+    - {name: q, type: General}
+  params:
+    - {name: modulus, type: int}
+    - {name: base, type: int}
+  impl:
+    - python: |
+        from ..algorithms.qec_examples import build_qec_small_shor
+    - python: |
+        build_qec_small_shor(self.program_list, self.q, self.modulus, self.base)

--- a/pyqres/generated/QECExampleBV.py
+++ b/pyqres/generated/QECExampleBV.py
@@ -1,0 +1,26 @@
+# Generated from YAML definition
+
+from ..core.operation import StandardComposite
+from ..core.registry import OperationRegistry
+from ..core.utils import merge_controllers
+import math
+from ..algorithms.qec_examples import build_qec_bv
+
+class QECExampleBV(StandardComposite):
+    """YAML mirror of QEC-Compiler Bernstein-Vazirani benchmark gates"""
+    def __init__(self, reg_list, param_list=None, operations=None):
+        if param_list is None:
+            param_list = []
+        StandardComposite.__init__(self, reg_list=reg_list, param_list=param_list, operations=operations)
+        self.q = reg_list[0]
+        self.n = param_list[0]
+        self.secret = param_list[1]
+        # Complex implementation with loops/conditionals
+        self._impl_structure = [{"_type": "python", "code": "from ..algorithms.qec_examples import build_qec_bv\n"}, {"_type": "python", "code": "build_qec_bv(self.program_list, self.q, self.n, self.secret)\n"}]
+        self._build_execute_method()
+
+    def _build_execute_method(self):
+        # Build program_list by expanding loops and conditionals
+        self.program_list = []
+        build_qec_bv(self.program_list, self.q, self.n, self.secret)
+        self.declare_program_list()

--- a/pyqres/generated/QECExampleDJ.py
+++ b/pyqres/generated/QECExampleDJ.py
@@ -1,0 +1,26 @@
+# Generated from YAML definition
+
+from ..core.operation import StandardComposite
+from ..core.registry import OperationRegistry
+from ..core.utils import merge_controllers
+import math
+from ..algorithms.qec_examples import build_qec_dj
+
+class QECExampleDJ(StandardComposite):
+    """YAML mirror of QEC-Compiler Deutsch-Jozsa benchmark gates"""
+    def __init__(self, reg_list, param_list=None, operations=None):
+        if param_list is None:
+            param_list = []
+        StandardComposite.__init__(self, reg_list=reg_list, param_list=param_list, operations=operations)
+        self.q = reg_list[0]
+        self.n = param_list[0]
+        self.balanced = param_list[1]
+        # Complex implementation with loops/conditionals
+        self._impl_structure = [{"_type": "python", "code": "from ..algorithms.qec_examples import build_qec_dj\n"}, {"_type": "python", "code": "build_qec_dj(self.program_list, self.q, self.n, self.balanced)\n"}]
+        self._build_execute_method()
+
+    def _build_execute_method(self):
+        # Build program_list by expanding loops and conditionals
+        self.program_list = []
+        build_qec_dj(self.program_list, self.q, self.n, self.balanced)
+        self.declare_program_list()

--- a/pyqres/generated/QECExampleGHZ.py
+++ b/pyqres/generated/QECExampleGHZ.py
@@ -1,0 +1,25 @@
+# Generated from YAML definition
+
+from ..core.operation import StandardComposite
+from ..core.registry import OperationRegistry
+from ..core.utils import merge_controllers
+import math
+from ..algorithms.qec_examples import build_qec_ghz
+
+class QECExampleGHZ(StandardComposite):
+    """YAML mirror of QEC-Compiler GHZ benchmark gates"""
+    def __init__(self, reg_list, param_list=None, operations=None):
+        if param_list is None:
+            param_list = []
+        StandardComposite.__init__(self, reg_list=reg_list, param_list=param_list, operations=operations)
+        self.q = reg_list[0]
+        self.n = param_list[0]
+        # Complex implementation with loops/conditionals
+        self._impl_structure = [{"_type": "python", "code": "from ..algorithms.qec_examples import build_qec_ghz\n"}, {"_type": "python", "code": "build_qec_ghz(self.program_list, self.q, self.n)\n"}]
+        self._build_execute_method()
+
+    def _build_execute_method(self):
+        # Build program_list by expanding loops and conditionals
+        self.program_list = []
+        build_qec_ghz(self.program_list, self.q, self.n)
+        self.declare_program_list()

--- a/pyqres/generated/QECExampleGrover.py
+++ b/pyqres/generated/QECExampleGrover.py
@@ -1,0 +1,28 @@
+# Generated from YAML definition
+
+from ..core.operation import StandardComposite
+from ..core.registry import OperationRegistry
+from ..core.utils import merge_controllers
+import math
+from ..algorithms.qec_examples import build_qec_grover
+
+class QECExampleGrover(StandardComposite):
+    """YAML mirror of QEC-Compiler Grover benchmark gates"""
+    def __init__(self, reg_list, param_list=None, operations=None):
+        if param_list is None:
+            param_list = []
+        StandardComposite.__init__(self, reg_list=reg_list, param_list=param_list, operations=operations)
+        self.q = reg_list[0]
+        self.n = param_list[0]
+        self.marked_states = param_list[1]
+        self.iterations = param_list[2]
+        # Complex implementation with loops/conditionals
+        self._impl_structure = [{"_type": "python", "code": "from ..algorithms.qec_examples import build_qec_grover\n"}, {"_type": "python", "code": "build_qec_grover(\n    self.program_list, self.q, self.n, self.marked_states, self.iterations)\n"}]
+        self._build_execute_method()
+
+    def _build_execute_method(self):
+        # Build program_list by expanding loops and conditionals
+        self.program_list = []
+        build_qec_grover(
+            self.program_list, self.q, self.n, self.marked_states, self.iterations)
+        self.declare_program_list()

--- a/pyqres/generated/QECExampleIsing.py
+++ b/pyqres/generated/QECExampleIsing.py
@@ -1,0 +1,30 @@
+# Generated from YAML definition
+
+from ..core.operation import StandardComposite
+from ..core.registry import OperationRegistry
+from ..core.utils import merge_controllers
+import math
+from ..algorithms.qec_examples import build_qec_ising
+
+class QECExampleIsing(StandardComposite):
+    """YAML mirror of QEC-Compiler Ising benchmark gates"""
+    def __init__(self, reg_list, param_list=None, operations=None):
+        if param_list is None:
+            param_list = []
+        StandardComposite.__init__(self, reg_list=reg_list, param_list=param_list, operations=operations)
+        self.q = reg_list[0]
+        self.n_spins = param_list[0]
+        self.couplings = param_list[1]
+        self.p_level = param_list[2]
+        self.h_transverse = param_list[3]
+        # Complex implementation with loops/conditionals
+        self._impl_structure = [{"_type": "python", "code": "from ..algorithms.qec_examples import build_qec_ising\n"}, {"_type": "python", "code": "build_qec_ising(\n    self.program_list, self.q, self.n_spins, self.couplings,\n    self.p_level, self.h_transverse)\n"}]
+        self._build_execute_method()
+
+    def _build_execute_method(self):
+        # Build program_list by expanding loops and conditionals
+        self.program_list = []
+        build_qec_ising(
+            self.program_list, self.q, self.n_spins, self.couplings,
+            self.p_level, self.h_transverse)
+        self.declare_program_list()

--- a/pyqres/generated/QECExampleQAOA.py
+++ b/pyqres/generated/QECExampleQAOA.py
@@ -1,0 +1,31 @@
+# Generated from YAML definition
+
+from ..core.operation import StandardComposite
+from ..core.registry import OperationRegistry
+from ..core.utils import merge_controllers
+import math
+from ..algorithms.qec_examples import build_qec_qaoa
+
+class QECExampleQAOA(StandardComposite):
+    """YAML mirror of QEC-Compiler QAOA benchmark gates"""
+    def __init__(self, reg_list, param_list=None, operations=None):
+        if param_list is None:
+            param_list = []
+        StandardComposite.__init__(self, reg_list=reg_list, param_list=param_list, operations=operations)
+        self.q = reg_list[0]
+        self.n_vertices = param_list[0]
+        self.edges = param_list[1]
+        self.p = param_list[2]
+        self.gamma = param_list[3]
+        self.beta = param_list[4]
+        # Complex implementation with loops/conditionals
+        self._impl_structure = [{"_type": "python", "code": "from ..algorithms.qec_examples import build_qec_qaoa\n"}, {"_type": "python", "code": "build_qec_qaoa(\n    self.program_list, self.q, self.n_vertices, self.edges,\n    self.p, self.gamma, self.beta)\n"}]
+        self._build_execute_method()
+
+    def _build_execute_method(self):
+        # Build program_list by expanding loops and conditionals
+        self.program_list = []
+        build_qec_qaoa(
+            self.program_list, self.q, self.n_vertices, self.edges,
+            self.p, self.gamma, self.beta)
+        self.declare_program_list()

--- a/pyqres/generated/QECExampleQFT.py
+++ b/pyqres/generated/QECExampleQFT.py
@@ -1,0 +1,25 @@
+# Generated from YAML definition
+
+from ..core.operation import StandardComposite
+from ..core.registry import OperationRegistry
+from ..core.utils import merge_controllers
+import math
+from ..algorithms.qec_examples import build_qec_qft
+
+class QECExampleQFT(StandardComposite):
+    """YAML mirror of QEC-Compiler QFT benchmark gates"""
+    def __init__(self, reg_list, param_list=None, operations=None):
+        if param_list is None:
+            param_list = []
+        StandardComposite.__init__(self, reg_list=reg_list, param_list=param_list, operations=operations)
+        self.q = reg_list[0]
+        self.n = param_list[0]
+        # Complex implementation with loops/conditionals
+        self._impl_structure = [{"_type": "python", "code": "from ..algorithms.qec_examples import build_qec_qft\n"}, {"_type": "python", "code": "build_qec_qft(self.program_list, self.q, self.n)\n"}]
+        self._build_execute_method()
+
+    def _build_execute_method(self):
+        # Build program_list by expanding loops and conditionals
+        self.program_list = []
+        build_qec_qft(self.program_list, self.q, self.n)
+        self.declare_program_list()

--- a/pyqres/generated/QECExampleQPE.py
+++ b/pyqres/generated/QECExampleQPE.py
@@ -1,0 +1,29 @@
+# Generated from YAML definition
+
+from ..core.operation import StandardComposite
+from ..core.registry import OperationRegistry
+from ..core.utils import merge_controllers
+import math
+from ..algorithms.qec_examples import build_qec_qpe
+
+class QECExampleQPE(StandardComposite):
+    """YAML mirror of QEC-Compiler QPE benchmark gates"""
+    def __init__(self, reg_list, param_list=None, operations=None):
+        if param_list is None:
+            param_list = []
+        StandardComposite.__init__(self, reg_list=reg_list, param_list=param_list, operations=operations)
+        self.q = reg_list[0]
+        self.n_counting = param_list[0]
+        self.n_system = param_list[1]
+        self.unitary_eigenvalue = param_list[2]
+        # Complex implementation with loops/conditionals
+        self._impl_structure = [{"_type": "python", "code": "from ..algorithms.qec_examples import build_qec_qpe\n"}, {"_type": "python", "code": "build_qec_qpe(\n    self.program_list, self.q, self.n_counting,\n    self.n_system, self.unitary_eigenvalue)\n"}]
+        self._build_execute_method()
+
+    def _build_execute_method(self):
+        # Build program_list by expanding loops and conditionals
+        self.program_list = []
+        build_qec_qpe(
+            self.program_list, self.q, self.n_counting,
+            self.n_system, self.unitary_eigenvalue)
+        self.declare_program_list()

--- a/pyqres/generated/QECExampleSmallShor.py
+++ b/pyqres/generated/QECExampleSmallShor.py
@@ -1,0 +1,26 @@
+# Generated from YAML definition
+
+from ..core.operation import StandardComposite
+from ..core.registry import OperationRegistry
+from ..core.utils import merge_controllers
+import math
+from ..algorithms.qec_examples import build_qec_small_shor
+
+class QECExampleSmallShor(StandardComposite):
+    """YAML mirror of QEC-Compiler small Shor fixture gates"""
+    def __init__(self, reg_list, param_list=None, operations=None):
+        if param_list is None:
+            param_list = []
+        StandardComposite.__init__(self, reg_list=reg_list, param_list=param_list, operations=operations)
+        self.q = reg_list[0]
+        self.modulus = param_list[0]
+        self.base = param_list[1]
+        # Complex implementation with loops/conditionals
+        self._impl_structure = [{"_type": "python", "code": "from ..algorithms.qec_examples import build_qec_small_shor\n"}, {"_type": "python", "code": "build_qec_small_shor(self.program_list, self.q, self.modulus, self.base)\n"}]
+        self._build_execute_method()
+
+    def _build_execute_method(self):
+        # Build program_list by expanding loops and conditionals
+        self.program_list = []
+        build_qec_small_shor(self.program_list, self.q, self.modulus, self.base)
+        self.declare_program_list()

--- a/pyqres/generated/QECExampleSwapTest.py
+++ b/pyqres/generated/QECExampleSwapTest.py
@@ -1,0 +1,25 @@
+# Generated from YAML definition
+
+from ..core.operation import StandardComposite
+from ..core.registry import OperationRegistry
+from ..core.utils import merge_controllers
+import math
+from ..algorithms.qec_examples import build_qec_swap_test
+
+class QECExampleSwapTest(StandardComposite):
+    """YAML mirror of QEC-Compiler SWAP-test benchmark gates"""
+    def __init__(self, reg_list, param_list=None, operations=None):
+        if param_list is None:
+            param_list = []
+        StandardComposite.__init__(self, reg_list=reg_list, param_list=param_list, operations=operations)
+        self.q = reg_list[0]
+        self.total_qubits = param_list[0]
+        # Complex implementation with loops/conditionals
+        self._impl_structure = [{"_type": "python", "code": "from ..algorithms.qec_examples import build_qec_swap_test\n"}, {"_type": "python", "code": "build_qec_swap_test(self.program_list, self.q, self.total_qubits)\n"}]
+        self._build_execute_method()
+
+    def _build_execute_method(self):
+        # Build program_list by expanding loops and conditionals
+        self.program_list = []
+        build_qec_swap_test(self.program_list, self.q, self.total_qubits)
+        self.declare_program_list()

--- a/pyqres/generated/QECExampleVQE.py
+++ b/pyqres/generated/QECExampleVQE.py
@@ -1,0 +1,29 @@
+# Generated from YAML definition
+
+from ..core.operation import StandardComposite
+from ..core.registry import OperationRegistry
+from ..core.utils import merge_controllers
+import math
+from ..algorithms.qec_examples import build_qec_vqe
+
+class QECExampleVQE(StandardComposite):
+    """YAML mirror of QEC-Compiler VQE benchmark gates"""
+    def __init__(self, reg_list, param_list=None, operations=None):
+        if param_list is None:
+            param_list = []
+        StandardComposite.__init__(self, reg_list=reg_list, param_list=param_list, operations=operations)
+        self.q = reg_list[0]
+        self.n_qubits = param_list[0]
+        self.layers = param_list[1]
+        self.ring_entanglement = param_list[2]
+        # Complex implementation with loops/conditionals
+        self._impl_structure = [{"_type": "python", "code": "from ..algorithms.qec_examples import build_qec_vqe\n"}, {"_type": "python", "code": "build_qec_vqe(\n    self.program_list, self.q, self.n_qubits,\n    self.layers, self.ring_entanglement)\n"}]
+        self._build_execute_method()
+
+    def _build_execute_method(self):
+        # Build program_list by expanding loops and conditionals
+        self.program_list = []
+        build_qec_vqe(
+            self.program_list, self.q, self.n_qubits,
+            self.layers, self.ring_entanglement)
+        self.declare_program_list()

--- a/pyqres/generated/QECExampleW.py
+++ b/pyqres/generated/QECExampleW.py
@@ -1,0 +1,25 @@
+# Generated from YAML definition
+
+from ..core.operation import StandardComposite
+from ..core.registry import OperationRegistry
+from ..core.utils import merge_controllers
+import math
+from ..algorithms.qec_examples import build_qec_w
+
+class QECExampleW(StandardComposite):
+    """YAML mirror of QEC-Compiler W-state benchmark gates"""
+    def __init__(self, reg_list, param_list=None, operations=None):
+        if param_list is None:
+            param_list = []
+        StandardComposite.__init__(self, reg_list=reg_list, param_list=param_list, operations=operations)
+        self.q = reg_list[0]
+        self.n = param_list[0]
+        # Complex implementation with loops/conditionals
+        self._impl_structure = [{"_type": "python", "code": "from ..algorithms.qec_examples import build_qec_w\n"}, {"_type": "python", "code": "build_qec_w(self.program_list, self.q, self.n)\n"}]
+        self._build_execute_method()
+
+    def _build_execute_method(self):
+        # Build program_list by expanding loops and conditionals
+        self.program_list = []
+        build_qec_w(self.program_list, self.q, self.n)
+        self.declare_program_list()

--- a/pyqres/generated/__init__.py
+++ b/pyqres/generated/__init__.py
@@ -7,6 +7,18 @@ from .CKSLinearSolver import CKSLinearSolver
 from .GroverSearch import GroverSearch
 from .QuantumPhaseEstimation import QuantumPhaseEstimation
 from .QDALinearSolver import QDALinearSolver
+from .QECExampleGHZ import QECExampleGHZ
+from .QECExampleW import QECExampleW
+from .QECExampleBV import QECExampleBV
+from .QECExampleDJ import QECExampleDJ
+from .QECExampleGrover import QECExampleGrover
+from .QECExampleQFT import QECExampleQFT
+from .QECExampleQPE import QECExampleQPE
+from .QECExampleQAOA import QECExampleQAOA
+from .QECExampleVQE import QECExampleVQE
+from .QECExampleIsing import QECExampleIsing
+from .QECExampleSwapTest import QECExampleSwapTest
+from .QECExampleSmallShor import QECExampleSmallShor
 from .QuantumBinarySearch import QuantumBinarySearch
 from .QuantumWalkSearch import QuantumWalkSearch
 from .QuantumWalkStep import QuantumWalkStep
@@ -21,6 +33,18 @@ __all__ = [
     "GroverSearch",
     "QuantumPhaseEstimation",
     "QDALinearSolver",
+    "QECExampleGHZ",
+    "QECExampleW",
+    "QECExampleBV",
+    "QECExampleDJ",
+    "QECExampleGrover",
+    "QECExampleQFT",
+    "QECExampleQPE",
+    "QECExampleQAOA",
+    "QECExampleVQE",
+    "QECExampleIsing",
+    "QECExampleSwapTest",
+    "QECExampleSmallShor",
     "QuantumBinarySearch",
     "QuantumWalkSearch",
     "QuantumWalkStep",

--- a/pyqres/primitives/__init__.py
+++ b/pyqres/primitives/__init__.py
@@ -49,7 +49,7 @@ from .measurement import (
 from .debug import DebugPrimitive, CheckNan, CheckNormalization
 
 # Intermediate / QEC-compiler layer
-from .intermediate import MCX, ADD, PLUS_ONE, REFLECT, MOD_ADD, MOD_MUL
+from .intermediate import MCX, ADD, PLUS_ONE, REFLECT, MOD_ADD, MOD_MUL, QECGate
 
 __all__ = [
     # Gates
@@ -94,5 +94,5 @@ __all__ = [
     "DebugPrimitive", "CheckNan", "CheckNormalization",
     # Intermediate / QEC-compiler layer
     "MCX", "ADD", "PLUS_ONE", "REFLECT",
-    "MOD_ADD", "MOD_MUL",
+    "MOD_ADD", "MOD_MUL", "QECGate",
 ]

--- a/pyqres/primitives/intermediate.py
+++ b/pyqres/primitives/intermediate.py
@@ -215,3 +215,43 @@ class MOD_MUL(Primitive):
         qubits = list(qubit_map[self.reg])
         return [_lazy_abstract_gate("MOD_MUL", tuple(qubits),
                                     (self.multiplier, self.modulus))]
+
+
+class QECGate(Primitive):
+    """Compiler-only adapter for exact QEC-Compiler example mirroring.
+
+    ``QECGate`` is intentionally not a portable algorithm primitive. It exists
+    so YAML-defined pyqres examples can emit the same gate-level
+    ``AbstractCircuit`` as QEC-Compiler's curated benchmark builders while
+    still flowing through the normal pyqres DSL/generated Operation path.
+
+    ``param_list`` shape:
+        ``[gate_name: str, qubits: list[int], params: list[float]]``
+    """
+
+    def __init__(self, reg_list=None, param_list=None):
+        super().__init__(reg_list=reg_list, param_list=param_list or [])
+        self.register = reg_list[0] if reg_list else None
+        self.gate_name = str(self.param_list[0])
+        self.bit_indices = tuple(int(q) for q in self.param_list[1])
+        raw_params = self.param_list[2] if len(self.param_list) > 2 else []
+        self.gate_params = tuple(float(p) for p in raw_params)
+
+    def pyqsparse_object(self, dagger_ctx=False, controllers_ctx=None):
+        raise NotImplementedError(
+            "QECGate is a compiler-only adapter for AbstractCircuit emission; "
+            "it has no PySparQ reference implementation."
+        )
+
+    def t_count(self, dagger_ctx=False, controllers_ctx=None):
+        raise NotImplementedError(
+            "QECGate does not define pyqres resource semantics. Use the emitted "
+            "AbstractCircuit/QEC-Compiler pipeline for resource computation."
+        )
+
+    def to_abstract_gates(self, qubit_map):
+        if self.register not in qubit_map:
+            raise ValueError(f"Register {self.register!r} is not allocated for QECGate")
+        reg_qubits = qubit_map[self.register]
+        qubits = tuple(reg_qubits[index] for index in self.bit_indices)
+        return [_lazy_abstract_gate(self.gate_name, qubits, self.gate_params)]

--- a/pyqres/primitives/qram.py
+++ b/pyqres/primitives/qram.py
@@ -1,15 +1,19 @@
-import pysparq
-import numpy as np
+"""QRAM primitives.
+
+QRAM support is intentionally disabled in the current pyqres -> QEC-Compiler
+workflow. Direct PySparQ QRAM experiments can still be run outside pyqres, but
+the pyqres wrappers must not provide dummy memories or approximate references
+until a shared QRAM contract is defined.
+"""
 
 from ..core.operation import Primitive
-from ..core.utils import merge_controllers
-from ..core.simulator import PyQSparseOperationWrapper
 
 
-def _make_memory(data_id):
-    import warnings
-    warnings.warn("Using a dummy memory for QRAM. This is not a realistic implementation.")
-    return np.zeros(2 ** 3)
+_QRAM_DISABLED_MESSAGE = (
+    "pyqres QRAM primitives are intentionally disabled for the current "
+    "pyqres -> QEC-Compiler workflow. Use direct PySparQ QRAM experiments "
+    "outside pyqres, or wait for the future QRAM contract/reference fix."
+)
 
 
 class QRAM(Primitive):
@@ -17,52 +21,32 @@ class QRAM(Primitive):
         super().__init__(reg_list=reg_list, param_list=param_list)
         self.reg_addr = reg_list[0]
         self.reg_data = reg_list[1]
-        self.data_id = param_list[0]
-        self.memory = _make_memory(self.data_id)
-
-        # Get register sizes from metadata
-        from ..core.metadata import RegisterMetadata
-        meta = RegisterMetadata.get_register_metadata()
-        addr_size = meta.registers.get(self.reg_addr, {}).get('size', 3)
-        data_size = meta.registers.get(self.reg_data, {}).get('size', 64)
-
-        self.qram = pysparq.QRAMCircuit_qutrit(
-            addr_size=int(addr_size),
-            data_size=int(data_size),
-            memory=[int(x) for x in self.memory]
-        )
+        self.data_id = param_list[0] if param_list else None
 
     def pyqsparse_object(self, dagger_ctx=False, controllers_ctx=None):
-        return pysparq.QRAMLoad(self.qram, self.reg_addr, self.reg_data)
+        raise NotImplementedError(_QRAM_DISABLED_MESSAGE)
 
     def t_count(self, dagger_ctx=False, controllers_ctx=None):
-        # QRAM resources are computed independently (QRAM_Count in the future).
-        # For now, exclude from T-count estimates.
-        return 0
+        raise NotImplementedError(_QRAM_DISABLED_MESSAGE)
 
 
 class QRAMFast(Primitive):
-    """Fast QRAM loading using the bucket-brigade protocol.
+    """Fast QRAM loading placeholder.
 
-    Loads data from a QRAM circuit at the address in addr_reg into data_reg.
-    Self-conjugate: loading the same address twice doesn't cancel (not self-adjoint
-    in general), but the operation itself is the same forward/inverse.
+    Kept as a registered primitive so existing YAML/Python definitions fail
+    explicitly instead of breaking imports.
     """
+
     __self_conjugate__ = True
 
     def __init__(self, reg_list, param_list):
         super().__init__(reg_list=reg_list, param_list=param_list)
-        self.qram = param_list[0]  # pysparq.QRAMCircuit_qutrit
+        self.qram = param_list[0] if param_list else None
         self.addr_reg = reg_list[0]
         self.data_reg = reg_list[1]
 
     def pyqsparse_object(self, dagger_ctx=False, controllers_ctx=None):
-        controllers_ctx = merge_controllers(self.controllers, controllers_ctx or {})
-        obj = PyQSparseOperationWrapper(
-            pysparq.QRAMLoadFast(self.qram, self.addr_reg, self.data_reg))
-        obj.set_controller(controllers_ctx)
-        return obj
+        raise NotImplementedError(_QRAM_DISABLED_MESSAGE)
 
     def t_count(self, dagger_ctx=False, controllers_ctx=None):
-        # QRAM resources are computed independently (QRAM_Count in the future).
-        return 0
+        raise NotImplementedError(_QRAM_DISABLED_MESSAGE)

--- a/tests/test_qec_examples_yaml.py
+++ b/tests/test_qec_examples_yaml.py
@@ -1,0 +1,145 @@
+"""YAML-defined mirrors of QEC-Compiler benchmark examples."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+pytest.importorskip("qec_compiler")
+
+from pyqres.core.lowering import to_abstract_circuit
+from pyqres.core.metadata import RegisterMetadata
+
+
+def _declare_q(size: int) -> None:
+    RegisterMetadata.get_register_metadata().declare_register("q", size, "General")
+
+
+def _assert_same_gate_circuit(actual, expected) -> None:
+    assert actual.num_qubits == expected.num_qubits
+    assert len(actual.gates) == len(expected.gates)
+    for got, want in zip(actual.gates, expected.gates, strict=True):
+        assert got.name == want.name
+        assert got.qubits == want.qubits
+        assert len(got.params) == len(want.params)
+        for got_param, want_param in zip(got.params, want.params, strict=True):
+            assert math.isclose(got_param, want_param, rel_tol=1e-12, abs_tol=1e-12)
+
+
+def _lower(op, num_qubits: int):
+    _declare_q(num_qubits)
+    return to_abstract_circuit(op)
+
+
+def test_yaml_ghz_matches_qec_compiler_builder():
+    from pyqres.generated import QECExampleGHZ
+    from qec_compiler.cases.benchmark_state_prep import build_ghz_circuit
+
+    expected = build_ghz_circuit(4, measure=False)
+    actual = _lower(QECExampleGHZ(["q"], [4]), expected.num_qubits)
+    _assert_same_gate_circuit(actual, expected)
+
+
+def test_yaml_w_matches_qec_compiler_builder():
+    from pyqres.generated import QECExampleW
+    from qec_compiler.cases.benchmark_state_prep import build_w_circuit
+
+    expected = build_w_circuit(4, measure=False)
+    actual = _lower(QECExampleW(["q"], [4]), expected.num_qubits)
+    _assert_same_gate_circuit(actual, expected)
+
+
+def test_yaml_bv_matches_qec_compiler_builder():
+    from pyqres.generated import QECExampleBV
+    from qec_compiler.cases.benchmark_bv import build_bv_circuit
+
+    expected = build_bv_circuit(4, secret=0b1010)
+    actual = _lower(QECExampleBV(["q"], [4, 0b1010]), expected.num_qubits)
+    _assert_same_gate_circuit(actual, expected)
+
+
+def test_yaml_dj_matches_qec_compiler_builder():
+    from pyqres.generated import QECExampleDJ
+    from qec_compiler.cases.benchmark_dj import build_dj_circuit
+
+    expected = build_dj_circuit(4, balanced=True)
+    actual = _lower(QECExampleDJ(["q"], [4, True]), expected.num_qubits)
+    _assert_same_gate_circuit(actual, expected)
+
+
+def test_yaml_grover_matches_qec_compiler_builder():
+    from pyqres.generated import QECExampleGrover
+    from qec_compiler.cases.benchmark_grover import build_grover_circuit
+
+    expected = build_grover_circuit(3, marked_states=(0,), iterations=1)
+    actual = _lower(QECExampleGrover(["q"], [3, [0], 1]), expected.num_qubits)
+    _assert_same_gate_circuit(actual, expected)
+
+
+def test_yaml_qft_matches_qec_compiler_builder():
+    from pyqres.generated import QECExampleQFT
+    from qec_compiler.cases.benchmark_qft import build_qft_circuit
+
+    expected = build_qft_circuit(4, measure=False)
+    actual = _lower(QECExampleQFT(["q"], [4]), expected.num_qubits)
+    _assert_same_gate_circuit(actual, expected)
+
+
+def test_yaml_qpe_matches_qec_compiler_builder():
+    from pyqres.generated import QECExampleQPE
+    from qec_compiler.cases.benchmark_qpe import build_qpe_circuit
+
+    expected = build_qpe_circuit(4, 2, unitary_eigenvalue=0.5)
+    actual = _lower(QECExampleQPE(["q"], [4, 2, 0.5]), expected.num_qubits)
+    _assert_same_gate_circuit(actual, expected)
+
+
+def test_yaml_qaoa_matches_qec_compiler_builder():
+    from pyqres.generated import QECExampleQAOA
+    from qec_compiler.cases.benchmark_qaoa import build_qaoa_circuit
+
+    edges = [(0, 1), (1, 2), (2, 3)]
+    expected = build_qaoa_circuit(4, edges, 1, gamma=math.pi / 4, beta=math.pi / 8)
+    actual = _lower(
+        QECExampleQAOA(["q"], [4, edges, 1, math.pi / 4, math.pi / 8]),
+        expected.num_qubits,
+    )
+    _assert_same_gate_circuit(actual, expected)
+
+
+def test_yaml_vqe_matches_qec_compiler_builder():
+    from pyqres.generated import QECExampleVQE
+    from qec_compiler.cases.benchmark_vqe import build_vqe_circuit
+
+    expected = build_vqe_circuit(4, layers=2, ring_entanglement=True)
+    actual = _lower(QECExampleVQE(["q"], [4, 2, True]), expected.num_qubits)
+    _assert_same_gate_circuit(actual, expected)
+
+
+def test_yaml_ising_matches_qec_compiler_builder():
+    from pyqres.generated import QECExampleIsing
+    from qec_compiler.cases.benchmark_ising import build_ising_circuit
+
+    couplings = [1.0, 1.0, 1.0]
+    expected = build_ising_circuit(4, couplings, p_level=1, h_transverse=1.0)
+    actual = _lower(QECExampleIsing(["q"], [4, couplings, 1, 1.0]), expected.num_qubits)
+    _assert_same_gate_circuit(actual, expected)
+
+
+def test_yaml_swap_test_matches_qec_compiler_builder():
+    from pyqres.generated import QECExampleSwapTest
+    from qec_compiler.cases.benchmark_swap_test import build_swap_test_circuit
+
+    expected = build_swap_test_circuit(5)
+    actual = _lower(QECExampleSwapTest(["q"], [5]), expected.num_qubits)
+    _assert_same_gate_circuit(actual, expected)
+
+
+def test_yaml_small_shor_matches_qec_compiler_builder():
+    from pyqres.generated import QECExampleSmallShor
+    from qec_compiler.cases.benchmark_shor import build_stage5_small_shor_fixture
+
+    expected = build_stage5_small_shor_fixture(modulus=15, base=2)
+    actual = _lower(QECExampleSmallShor(["q"], [15, 2]), expected.num_qubits)
+    _assert_same_gate_circuit(actual, expected)

--- a/tests/test_qec_lowering.py
+++ b/tests/test_qec_lowering.py
@@ -218,6 +218,19 @@ class TestEndToEndCompilation:
         assert [g.name for g in mod_mul_circuit.gates] == ["MOD_MUL"]
         assert lower_to_logical(mod_mul_circuit).ccz_inject_count > 0
 
+    def test_mod_add_allocates_clean_flag_qubit(self):
+        """MOD_ADD lowering emits a clean flag ancilla and counts it in num_qubits."""
+        from pyqres.primitives import MOD_ADD
+
+        _declare_reg("a", 2, "UnsignedInteger")
+        _declare_reg("b", 2, "UnsignedInteger")
+        circuit = _to_circuit(MOD_ADD(reg_list=["a", "b"], param_list=[3]))
+
+        assert circuit.num_qubits == 5
+        assert [g.name for g in circuit.gates] == ["MOD_ADD"]
+        assert circuit.gates[0].qubits == (0, 1, 2, 3, 4)
+        assert circuit.gates[0].params == (3.0,)
+
     def test_intermediate_dagger_gate_names(self):
         """Intermediate arithmetic dagger lowers to inverse QEC gate names."""
         from pyqres.primitives import ADD, MOD_ADD, MOD_MUL, PLUS_ONE
@@ -383,3 +396,37 @@ class TestWalkSLowering:
         circuit = _to_circuit(op)
         logical = lower_to_logical(circuit)
         assert logical.ccz_inject_count > 0
+
+    @pytest.mark.parametrize("main_bits", [1, 2, 3])
+    def test_generated_qda_tridiagonal_lowers_for_matrix_sizes(self, main_bits):
+        """QDA-tridiagonal lowers automatically for multiple matrix dimensions."""
+        from pyqres.algorithms.block_encoding import BlockEncodingTridiagonal
+        from pyqres.generated import QDALinearSolver
+        from qec_compiler.decomposition import lower_to_logical
+
+        _declare_reg("main", main_bits, "UnsignedInteger")
+        _declare_reg("anc_UA", 4, "UnsignedInteger")
+        _declare_reg("anc_1", 1, "Boolean")
+        _declare_reg("anc_2", 1, "Boolean")
+        _declare_reg("anc_3", 1, "Boolean")
+        _declare_reg("anc_4", 1, "Boolean")
+
+        def make_enc_A(reg_list=None, param_list=None):
+            return BlockEncodingTridiagonal(
+                reg_list=reg_list,
+                main_reg=reg_list[0],
+                anc_UA=reg_list[1],
+                alpha=0.5,
+                beta=0.3,
+            )
+
+        op = QDALinearSolver(
+            reg_list=["main", "anc_UA", "anc_1", "anc_2", "anc_3", "anc_4"],
+            param_list=[2.0, 1.0],
+            operations=[make_enc_A],
+        )
+
+        circuit = _to_circuit(op)
+        assert circuit.num_qubits >= main_bits + 8
+        assert len(circuit.gates) > 0
+        assert lower_to_logical(circuit).ccz_inject_count is not None

--- a/tests/test_qram_unimplemented.py
+++ b/tests/test_qram_unimplemented.py
@@ -1,0 +1,29 @@
+"""QRAM is explicitly disabled in the current pyqres/QEC workflow."""
+
+from __future__ import annotations
+
+import pytest
+
+from pyqres.core.metadata import RegisterMetadata
+
+
+def _declare_qram_regs() -> None:
+    rm = RegisterMetadata.get_register_metadata()
+    rm.declare_register("addr", 2, "UnsignedInteger")
+    rm.declare_register("data", 3, "UnsignedInteger")
+
+
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="QRAM contract deferred")
+def test_qram_reference_is_deferred_xfail():
+    from pyqres.primitives import QRAM
+
+    _declare_qram_regs()
+    QRAM(["addr", "data"], [0]).pyqsparse_object()
+
+
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="QRAM contract deferred")
+def test_qramfast_reference_is_deferred_xfail():
+    from pyqres.primitives import QRAMFast
+
+    _declare_qram_regs()
+    QRAMFast(["addr", "data"], [None]).pyqsparse_object()


### PR DESCRIPTION
## Summary
- add pyqres YAML-facing QEC example wrappers and generated operation classes
- add QECGate as a compiler-only bridge into QEC-Compiler AbstractCircuit gates
- document the pyqres -> QEC-Compiler workflow, supported algorithms, QDA tridiagonal path, and QRAM deferral
- make pyqres QRAM primitives fail explicitly with NotImplementedError until a QRAM contract is finalized
- add regression tests for QEC example YAML parity, QRAM xfail behavior, MOD_ADD clean flag allocation, and QDA tridiagonal lowering

## Validation
- pyqres compile
- pyqres check
- targeted pyqres tests: 41 passed, 2 xfailed
- QEC arithmetic tests: 30 passed

## Notes
QRAM/PySparQ integration is intentionally left out of this stage. The current contract is explicit NotImplementedError plus xfail tests, so unsupported QRAM behavior is visible rather than silently producing misleading results.